### PR TITLE
Align indexing strategies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ python-dateutil==2.8.1
 pytz==2020.1
 PyYAML==5.3.1
 rac-schemas==0.8
+rac_es==0.2.1
 shortuuid==1.0.1
 six==1.14.0
 sqlparse==0.3.1
@@ -22,4 +23,3 @@ uritemplate==3.0.1
 urllib3==1.25.9
 zipp==3.1.0
 zope.interface==5.1.0
-git+https://github.com/RockefellerArchiveCenter/rac_es#egg=rac_es


### PR DESCRIPTION
Use common indexing functions in `rac_es` to index documents so that tests here reflect what's happening in scorpio.