### PR TITLE
Returns correct object counts in pagination

### DIFF
--- a/api_formatter/view_helpers.py
+++ b/api_formatter/view_helpers.py
@@ -15,7 +15,6 @@ from django_elasticsearch_dsl_drf.filter_backends import (CompoundSearchFilterBa
                                                           FacetedSearchFilterBackend,
                                                           FilteringFilterBackend,
                                                           OrderingFilterBackend)
-from django_elasticsearch_dsl_drf.pagination import PageNumberPagination
 from elasticsearch_dsl import Index, Search, connections
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
@@ -39,12 +38,9 @@ NUMBER_LOOKUPS = [
 FILTER_BACKENDS = [FilteringFilterBackend,
                    OrderingFilterBackend,
                    DefaultOrderingFilterBackend,
-                   CompoundSearchFilterBackend,
-                   ]
+                   CompoundSearchFilterBackend]
 
 SEARCH_BACKENDS = FILTER_BACKENDS + [FacetedSearchFilterBackend]
-
-PAGINATION_CLASS = PageNumberPagination
 
 
 class SearchMixin:

--- a/api_formatter/views.py
+++ b/api_formatter/views.py
@@ -7,13 +7,12 @@ from .serializers import (AgentListSerializer, AgentSerializer,
                           CollectionListSerializer, CollectionSerializer,
                           HitSerializer, ObjectListSerializer,
                           ObjectSerializer, TermListSerializer, TermSerializer)
-from .view_helpers import (FILTER_BACKENDS, NUMBER_LOOKUPS, PAGINATION_CLASS,
-                           SEARCH_BACKENDS, STRING_LOOKUPS, SearchMixin)
+from .view_helpers import (FILTER_BACKENDS, NUMBER_LOOKUPS, SEARCH_BACKENDS,
+                           STRING_LOOKUPS, SearchMixin)
 
 
 class DocumentViewSet(SearchMixin, ReadOnlyModelViewSet):
     filter_backends = FILTER_BACKENDS
-    pagination_class = PAGINATION_CLASS
 
     def get_serializer_class(self):
         if self.action == "list":
@@ -170,7 +169,6 @@ class SearchView(DocumentViewSet):
     """
 
     list_serializer = HitSerializer
-    pagination_class = PAGINATION_CLASS
     filter_backends = SEARCH_BACKENDS
 
     # TODO: determine if we need filter fields here


### PR DESCRIPTION
Removes `elasticsearch_dsl_drf` pagination in favor of base DRF pagination, which actually works!