### PR TITLE
Adds sorting params

### DIFF
--- a/api_formatter/serializers.py
+++ b/api_formatter/serializers.py
@@ -151,14 +151,10 @@ class CollectionHitSerializer(serializers.Serializer):
 
     This requires secondary resolution of hits when they are loaded.
     """
-    uri = serializers.SerializerMethodField()
-    hit_count = serializers.SerializerMethodField()
-
-    def get_uri(self, obj):
-        return obj.group.identifier
-
-    def get_hit_count(self, obj):
-        return obj.meta.inner_hits.collection_hits.hits.total.value
+    dates = serializers.CharField(source="group.dates")
+    hit_count = serializers.CharField(source="meta.inner_hits.collection_hits.hits.total.value")
+    title = serializers.CharField(source="group.title")
+    uri = serializers.CharField(source="group.identifier")
 
 
 class FacetSerializer(serializers.Serializer):

--- a/api_formatter/serializers.py
+++ b/api_formatter/serializers.py
@@ -151,10 +151,20 @@ class CollectionHitSerializer(serializers.Serializer):
 
     This requires secondary resolution of hits when they are loaded.
     """
-    dates = serializers.CharField(source="group.dates")
+    dates = serializers.SerializerMethodField()
     hit_count = serializers.CharField(source="meta.inner_hits.collection_hits.hits.total.value")
     title = serializers.CharField(source="group.title")
     uri = serializers.CharField(source="group.identifier")
+    creators = serializers.SerializerMethodField()
+
+    def get_dates(self, obj):
+        return [d.expression for d in obj.group.dates]
+
+    def get_creators(self, obj):
+        if getattr(obj.group, "creators", None):
+            return [c.title for c in obj.group.creators]
+        else:
+            return []
 
 
 class FacetSerializer(serializers.Serializer):

--- a/api_formatter/views.py
+++ b/api_formatter/views.py
@@ -190,7 +190,15 @@ class SearchView(DocumentViewSet):
             "path": "creators"
         }
     }
-    ordering_fields = {"title": "title.keyword", "type": "type.keyword"}
+    ordering_fields = {
+        "title": "group.title",
+        "start_date": "group.dates.begin",
+        "end_date": "group.dates.end",
+        "creator": {
+            "field": "group.creators.title.keyword",
+            "path": "group.creators"
+        }
+    }
     search_fields = ("title", "description", "type", "")
     search_nested_fields = {
         "notes": {"path": "notes", "fields": ["subnotes.content"]},


### PR DESCRIPTION
Implements sort fields for title, creator and date.

Notes:
- I had to implement a custom sort backend, because of the issue described here: https://github.com/barseghyanartur/django-elasticsearch-dsl-drf/issues/212. Hoping that gets addressed and I can get rid of my custom code.

fixes #84