### PR TITLE
Add ancestors endpoint

### DIFF
--- a/api_formatter/serializers.py
+++ b/api_formatter/serializers.py
@@ -206,3 +206,22 @@ class FacetSerializer(serializers.Serializer):
             else:
                 resp[k] = v
         return resp
+
+
+class AncestorsSerializer(serializers.Serializer):
+    """Provides a nested dictionary representation of ancestors"""
+
+    def serialize_ancestors(self, ancestor_list, tree, idx):
+        ancestor = ancestor_list[idx]
+        serialized = ReferenceSerializer(ancestor).data
+        new_tree = {ancestor.identifier: {**serialized, **tree}}
+        if idx == len(ancestor_list) - 1:
+            return new_tree
+        else:
+            return self.serialize_ancestors(ancestor_list, new_tree, idx + 1)
+
+    def to_representation(self, instance):
+        resp = {}
+        if instance:
+            resp = self.serialize_ancestors(instance, {}, 0)
+        return resp

--- a/api_formatter/serializers.py
+++ b/api_formatter/serializers.py
@@ -133,7 +133,6 @@ class CollectionSerializer(BaseDetailSerializer):
     agents = ReferenceSerializer(many=True, allow_null=True)
     creators = ReferenceSerializer(many=True, allow_null=True)
     terms = ReferenceSerializer(many=True, allow_null=True)
-    ancestors = ReferenceSerializer(many=True, allow_null=True)
     children = ReferenceSerializer(many=True, allow_null=True)
 
 
@@ -149,7 +148,6 @@ class ObjectSerializer(BaseDetailSerializer):
     rights_statements = RightsStatementSerializer(many=True, allow_null=True)
     agents = ReferenceSerializer(many=True, allow_null=True)
     terms = ReferenceSerializer(many=True, allow_null=True)
-    ancestors = ReferenceSerializer(many=True, allow_null=True)
 
 
 class ObjectListSerializer(BaseListSerializer):
@@ -209,15 +207,17 @@ class FacetSerializer(serializers.Serializer):
 
 
 class AncestorsSerializer(serializers.Serializer):
-    """Provides a nested dictionary representation of ancestors"""
+    """Provides a nested dictionary representation of ancestors."""
 
     def serialize_ancestors(self, ancestor_list, tree, idx):
         ancestor = ancestor_list[idx]
         serialized = ReferenceSerializer(ancestor).data
-        new_tree = {ancestor.identifier: {**serialized, **tree}}
+        tree_data = {**serialized, **tree}
         if idx == len(ancestor_list) - 1:
+            new_tree = tree_data
             return new_tree
         else:
+            new_tree = {"child": tree_data}
             return self.serialize_ancestors(ancestor_list, new_tree, idx + 1)
 
     def to_representation(self, instance):

--- a/api_formatter/views.py
+++ b/api_formatter/views.py
@@ -3,17 +3,31 @@ from django_elasticsearch_dsl_drf.pagination import LimitOffsetPagination
 from elasticsearch_dsl import A, Q
 from rac_es.documents import (Agent, BaseDescriptionComponent, Collection,
                               Object, Term)
+from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from .pagination import CollapseLimitOffsetPagination
 from .serializers import (AgentListSerializer, AgentSerializer,
-                          CollectionHitSerializer, CollectionListSerializer,
-                          CollectionSerializer, FacetSerializer,
-                          ObjectListSerializer, ObjectSerializer,
-                          TermListSerializer, TermSerializer)
+                          AncestorsSerializer, CollectionHitSerializer,
+                          CollectionListSerializer, CollectionSerializer,
+                          FacetSerializer, ObjectListSerializer,
+                          ObjectSerializer, TermListSerializer, TermSerializer)
 from .view_helpers import (FILTER_BACKENDS, NUMBER_LOOKUPS, SEARCH_BACKENDS,
                            STRING_LOOKUPS, SearchMixin)
+
+
+class AncestorMixin(object):
+    @action(detail=True)
+    def ancestors(self, request, pk=None):
+        obj = self.document.get(id=pk)
+        ancestors = list(getattr(obj, "ancestors", []))
+        if ancestors:
+            resource = Collection.get(id=obj.ancestors[-1].identifier)
+            if getattr(resource, "ancestors"):
+                ancestors += list(resource.ancestors)
+        serializer = AncestorsSerializer(ancestors)
+        return Response(serializer.data)
 
 
 class DocumentViewSet(SearchMixin, ReadOnlyModelViewSet):
@@ -88,7 +102,7 @@ class AgentViewSet(DocumentViewSet):
     }
 
 
-class CollectionViewSet(DocumentViewSet):
+class CollectionViewSet(DocumentViewSet, AncestorMixin):
     """
     Returns data about collections, or intellectually significant groups of archival records.
     """
@@ -149,7 +163,7 @@ class CollectionViewSet(DocumentViewSet):
         return obj
 
 
-class ObjectViewSet(DocumentViewSet):
+class ObjectViewSet(DocumentViewSet, AncestorMixin):
     """
     Returns data about objects, or groups of archival records which have no children.
     """

--- a/api_formatter/views.py
+++ b/api_formatter/views.py
@@ -18,6 +18,12 @@ from .view_helpers import (FILTER_BACKENDS, NUMBER_LOOKUPS, SEARCH_BACKENDS,
 
 
 class AncestorMixin(object):
+    """Provides an ancestors detail route.
+
+    Returns a nested dictionary representation of the complete ancestor tree for
+    a collection or object.
+    """
+
     @action(detail=True)
     def ancestors(self, request, pk=None):
         obj = self.document.get(id=pk)
@@ -73,9 +79,7 @@ class DocumentViewSet(SearchMixin, ReadOnlyModelViewSet):
 
 
 class AgentViewSet(DocumentViewSet):
-    """
-    Returns data about agents, including people, organizations and families.
-    """
+    """Returns data about agents, including people, organizations and families."""
 
     document = Agent
     list_serializer = AgentListSerializer
@@ -103,9 +107,7 @@ class AgentViewSet(DocumentViewSet):
 
 
 class CollectionViewSet(DocumentViewSet, AncestorMixin):
-    """
-    Returns data about collections, or intellectually significant groups of archival records.
-    """
+    """Returns data about collections, or intellectually significant groups of archival records."""
 
     document = Collection
     list_serializer = CollectionListSerializer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,28 +15,28 @@ services:
     depends_on:
       - argo-db
 
-  # elasticsearch:
-  #   image: elasticsearch:7.0.0
-  #   environment:
-  #     - node.name=elasticsearch
-  #     - discovery.seed_hosts=elasticsearch
-  #     - cluster.initial_master_nodes=elasticsearch
-  #     - cluster.name=docker-cluster
-  #     - bootstrap.memory_lock=true
-  #     - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-  #     - http.cors.enabled=true
-  #     - http.cors.allow-origin=http://localhost:8000
-  #     - http.cors.allow-headers=Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With
-  #     - http.cors.allow-credentials=true
-  #   ulimits:
-  #     memlock:
-  #       soft: -1
-  #       hard: -1
-  #   volumes:
-  #     - elasticsearch:/usr/share/elasticsearch/data
-  #   ports:
-  #     - 9200:9200
+  elasticsearch:
+    image: elasticsearch:7.0.0
+    environment:
+      - node.name=elasticsearch
+      - discovery.seed_hosts=elasticsearch
+      - cluster.initial_master_nodes=elasticsearch
+      - cluster.name=docker-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - http.cors.enabled=true
+      - http.cors.allow-origin=http://localhost:8000
+      - http.cors.allow-headers=Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With
+      - http.cors.allow-credentials=true
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - elasticsearch:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
 
 volumes:
   argodbvolume:
-  # elasticsearch:
+  elasticsearch:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,28 +15,28 @@ services:
     depends_on:
       - argo-db
 
-  elasticsearch:
-    image: elasticsearch:7.0.0
-    environment:
-      - node.name=elasticsearch
-      - discovery.seed_hosts=elasticsearch
-      - cluster.initial_master_nodes=elasticsearch
-      - cluster.name=docker-cluster
-      - bootstrap.memory_lock=true
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-      - http.cors.enabled=true
-      - http.cors.allow-origin=http://localhost:8000
-      - http.cors.allow-headers=Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With
-      - http.cors.allow-credentials=true
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-    volumes:
-      - elasticsearch:/usr/share/elasticsearch/data
-    ports:
-      - 9200:9200
+  # elasticsearch:
+  #   image: elasticsearch:7.0.0
+  #   environment:
+  #     - node.name=elasticsearch
+  #     - discovery.seed_hosts=elasticsearch
+  #     - cluster.initial_master_nodes=elasticsearch
+  #     - cluster.name=docker-cluster
+  #     - bootstrap.memory_lock=true
+  #     - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+  #     - http.cors.enabled=true
+  #     - http.cors.allow-origin=http://localhost:8000
+  #     - http.cors.allow-headers=Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With
+  #     - http.cors.allow-credentials=true
+  #   ulimits:
+  #     memlock:
+  #       soft: -1
+  #       hard: -1
+  #   volumes:
+  #     - elasticsearch:/usr/share/elasticsearch/data
+  #   ports:
+  #     - 9200:9200
 
 volumes:
   argodbvolume:
-  elasticsearch:
+  # elasticsearch:


### PR DESCRIPTION
Adds an AncestorsMixin which is called in both objects and collections to provide a detail endpoint with a nested representation of ancestors.

fixes #95 