### PR TITLE
Improve query structure

### DIFF
--- a/api_formatter/view_helpers.py
+++ b/api_formatter/view_helpers.py
@@ -9,15 +9,11 @@ from django_elasticsearch_dsl_drf.constants import (LOOKUP_FILTER_PREFIX,
                                                     LOOKUP_QUERY_GTE,
                                                     LOOKUP_QUERY_IN,
                                                     LOOKUP_QUERY_LT,
-                                                    LOOKUP_QUERY_LTE,
-                                                    MATCHING_OPTION_SHOULD)
+                                                    LOOKUP_QUERY_LTE)
 from django_elasticsearch_dsl_drf.filter_backends import (DefaultOrderingFilterBackend,
                                                           FilteringFilterBackend,
                                                           NestedFilteringFilterBackend,
-                                                          OrderingFilterBackend,
-                                                          SimpleQueryStringSearchFilterBackend)
-from django_elasticsearch_dsl_drf.filter_backends.search.query_backends import (NestedQueryBackend,
-                                                                                SimpleQueryStringQueryBackend)
+                                                          OrderingFilterBackend)
 from django_elasticsearch_dsl_drf.pagination import LimitOffsetPagination
 from elasticsearch_dsl import Index, Search, connections
 from rest_framework.viewsets import ReadOnlyModelViewSet
@@ -90,19 +86,9 @@ class CustomOrderingBackend(OrderingFilterBackend):
         return _ordering_params
 
 
-class CustomSearchBackend(SimpleQueryStringSearchFilterBackend):
-    search_param = "query"
-    matching = MATCHING_OPTION_SHOULD
-    query_backends = [
-        SimpleQueryStringQueryBackend,
-        NestedQueryBackend
-    ]
-
-
 FILTER_BACKENDS = [FilteringFilterBackend,
                    CustomOrderingBackend,
-                   DefaultOrderingFilterBackend,
-                   CustomSearchBackend]
+                   DefaultOrderingFilterBackend]
 
 FILTER_FIELDS = {
     "category": {"field": "category", "lookups": STRING_LOOKUPS},

--- a/api_formatter/views.py
+++ b/api_formatter/views.py
@@ -1,3 +1,4 @@
+from argo import settings
 from django.http import Http404
 from django_elasticsearch_dsl_drf.pagination import LimitOffsetPagination
 from elasticsearch_dsl import A, Q
@@ -330,7 +331,7 @@ class SearchView(DocumentViewSet):
         return self.search.extra(collapse=collapse_params).query()
 
     def filter_queryset(self, queryset):
-        query = self.request.GET.get("query")
+        query = self.request.GET.get(settings.REST_FRAMEWORK["SEARCH_PARAM"])
         queryset.query = Q("bool",
                            should=[
                                Q("simple_query_string",

--- a/api_formatter/views.py
+++ b/api_formatter/views.py
@@ -314,11 +314,6 @@ class SearchView(DocumentViewSet):
             "path": "group.creators"
         }
     }
-    simple_query_string_search_fields = {"title": {"boost": 2}, "description": None}
-    simple_query_string_options = {"default_operator": "and"}
-    search_nested_fields = {
-        "notes": {"path": "notes", "fields": ["subnotes.content"]},
-    }
 
     def get_queryset(self):
         """Uses `collapse` to group hits based on `group` attribute."""
@@ -333,6 +328,22 @@ class SearchView(DocumentViewSet):
         a = A("cardinality", field="group.identifier")
         self.search.aggs.bucket("total", a)
         return self.search.extra(collapse=collapse_params).query()
+
+    def filter_queryset(self, queryset):
+        query = self.request.GET.get("query")
+        queryset.query = Q("bool",
+                           should=[
+                               Q("simple_query_string",
+                                 query=query,
+                                 fields=["title^5", "description"],
+                                   default_operator="and"),
+                               Q("nested",
+                                 path="notes",
+                                 query=Q("simple_query_string",
+                                         query=query,
+                                         fields=["notes.subnotes.content"],
+                                         default_operator="and"))])
+        return queryset
 
 
 class FacetView(SearchView):

--- a/api_formatter/views.py
+++ b/api_formatter/views.py
@@ -336,7 +336,7 @@ class SearchView(DocumentViewSet):
                                Q("simple_query_string",
                                  query=query,
                                  fields=["title^5", "description"],
-                                   default_operator="and"),
+                                 default_operator="and"),
                                Q("nested",
                                  path="notes",
                                  query=Q("simple_query_string",


### PR DESCRIPTION
Manually construct a query in the `filter_queryset` method of the `SearchView`, which gives us greater control over its structure.

Actually fixes #117, unlike previous commits.