### PR TITLE
Debug new child endpoint

### DIFF
--- a/api_formatter/views.py
+++ b/api_formatter/views.py
@@ -248,8 +248,7 @@ class CollectionViewSet(DocumentViewSet, AncestorMixin):
         ).sort("position")
         obj = self.resolve_object(Collection, pk, source_fields=["group"])
         paginator = ChildrenPaginator()
-        queryset = super(DocumentViewSet, self).filter_queryset(child_hits)
-        page = paginator.paginate_queryset(queryset, request)
+        page = paginator.paginate_queryset(child_hits, request)
         if page is not None:
             page = self.prepare_children(page, obj.group)
             serializer = ReferenceSerializer(page, many=True)


### PR DESCRIPTION
Fixes a number of bugs in the new `children` endpoint:
- Uses the correct identifier when searching for hits in objects.
- Removes `parent` attributes from searches, fixes #129 
- Don't call `filter_queryset` on children, fixes #130 