### PR TITLE
Remove /terms endpoint and update filter fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ The first time the container is started, the example config file (`/argo/config.
 |GET|/agents||200|Returns data about Agents|
 |GET|/collections||200|Returns data about Collections|
 |GET|/objects||200|Returns data about Objects|
-|GET|/terms||200|Returns data about Terms|
 |GET|/search||200|Returns search data|
 |GET|/schema/||200|Returns the OpenAPI schema|
 

--- a/api_formatter/serializers.py
+++ b/api_formatter/serializers.py
@@ -92,10 +92,6 @@ class ReferenceSerializer(serializers.Serializer):
         basename = obj.type
         if basename in ["person", "organization", "family", "software"]:
             basename = "agent"
-        elif basename in ["cultural_context", "function", "geographic",
-                          "genre_form", "occupation", "style_period", "technique",
-                          "temporal", "topical"]:
-            basename = "term"
         return reverse('{}-detail'.format(basename), kwargs={"pk": obj.identifier})
 
 

--- a/api_formatter/serializers.py
+++ b/api_formatter/serializers.py
@@ -95,7 +95,8 @@ class ReferenceSerializer(serializers.Serializer):
         elif basename in ["cultural_context", "function", "geographic",
                           "genre_form", "occupation", "style_period", "technique",
                           "temporal", "topical"]:
-            basename = "term"
+            # basename = "term"
+            return None
         return reverse('{}-detail'.format(basename), kwargs={"pk": obj.identifier})
 
 

--- a/api_formatter/serializers.py
+++ b/api_formatter/serializers.py
@@ -92,6 +92,10 @@ class ReferenceSerializer(serializers.Serializer):
         basename = obj.type
         if basename in ["person", "organization", "family", "software"]:
             basename = "agent"
+        elif basename in ["cultural_context", "function", "geographic",
+                          "genre_form", "occupation", "style_period", "technique",
+                          "temporal", "topical"]:
+            basename = "term"
         return reverse('{}-detail'.format(basename), kwargs={"pk": obj.identifier})
 
 

--- a/api_formatter/templates/rest_framework/api.html
+++ b/api_formatter/templates/rest_framework/api.html
@@ -164,7 +164,7 @@
     {% endif %}
 
     <div class="request-info" style="clear: both" aria-label="{% trans "request info" %}">
-      <pre class="prettyprint"><span class=font-weight-bold>{{ request.method }}</span> {{ request.get_full_path }}</pre>
+      <pre class="prettyprint"><span class="font-weight-bold">{{ request.method }}</span> {{ request.get_full_path }}</pre>
     </div>
 
     <div class="response-info" aria-label="{% trans "response info" %}">

--- a/api_formatter/templates/rest_framework/api.html
+++ b/api_formatter/templates/rest_framework/api.html
@@ -162,12 +162,12 @@
     {% endif %}
 
     <div class="request-info" style="clear: both" aria-label="{% trans "request info" %}">
-      <pre class="prettyprint"><b>{{ request.method }}</b> {{ request.get_full_path }}</pre>
+      <pre class="prettyprint"><span class=font-weight-bold>{{ request.method }}</span> {{ request.get_full_path }}</pre>
     </div>
 
     <div class="response-info" aria-label="{% trans "response info" %}">
-      <pre class="prettyprint"><span class="meta nocode"><b>HTTP {{ response.status_code }} {{ response.status_text }}</b>{% autoescape off %}{% for key, val in response_headers|items %}
-<b>{{ key }}:</b> <span class="lit">{{ val|break_long_headers|urlize }}</span>{% endfor %}
+      <pre class="prettyprint"><span class="meta nocode"><span class="font-weight-bold">HTTP {{ response.status_code }} {{ response.status_text }}</span>{% autoescape off %}{% for key, val in response_headers|items %}
+<span class="font-weight-bold">{{ key }}:</span> <span class="lit">{{ val|break_long_headers|urlize }}</span>{% endfor %}
 
 </span>{{ content|urlize }}</pre>{% endautoescape %}
     </div>

--- a/api_formatter/templates/rest_framework/api.html
+++ b/api_formatter/templates/rest_framework/api.html
@@ -122,6 +122,9 @@
         {% for field in view.filter_fields %}
           <li>{{field}}</li>
         {% endfor %}
+        {% for field in view.nested_filter_fields %}
+          <li>{{field}}</li>
+        {% endfor %}
         </ul>
         </div>
         {% endif %}

--- a/api_formatter/templates/rest_framework/api.html
+++ b/api_formatter/templates/rest_framework/api.html
@@ -22,7 +22,6 @@
       <li class="nav-item"><a class="nav-link" href="{% url 'agent-list' %}">Agents</a></li>
       <li class="nav-item"><a class="nav-link" href="{% url 'collection-list' %}">Collections</a></li>
       <li class="nav-item"><a class="nav-link" href="{% url 'object-list' %}">Objects</a></li>
-      <li class="nav-item"><a class="nav-link" href="{% url 'term-list' %}">Terms</a></li>
     </ul>
   </div>
 </div>

--- a/api_formatter/tests.py
+++ b/api_formatter/tests.py
@@ -9,19 +9,18 @@ from django.urls import reverse
 from elasticsearch.helpers import streaming_bulk
 from elasticsearch_dsl import connections, utils
 from rac_es.documents import (Agent, BaseDescriptionComponent, Collection,
-                              Object, Term)
+                              Object)
 from rac_schemas import is_valid
 from rest_framework.test import APIRequestFactory
 
 from .view_helpers import date_string
 from .views import (AgentViewSet, CollectionViewSet, MyListView, ObjectViewSet,
-                    SearchView, TermViewSet)
+                    SearchView)
 
 TYPE_MAP = (
     ('agent', Agent, AgentViewSet),
     ('collection', Collection, CollectionViewSet),
     ('object', Object, ObjectViewSet),
-    ('term', Term, TermViewSet),
 )
 
 STOP_WORDS = ["a", "an", "and", "are", "as", "at", "be", "but", "by", "for", "if",

--- a/api_formatter/tests.py
+++ b/api_formatter/tests.py
@@ -9,19 +9,19 @@ from django.urls import reverse
 from elasticsearch.helpers import streaming_bulk
 from elasticsearch_dsl import connections, utils
 from rac_es.documents import (Agent, BaseDescriptionComponent, Collection,
-                              Object, Term)
+                              Object)
 from rac_schemas import is_valid
 from rest_framework.test import APIRequestFactory
 
 from .view_helpers import date_string
 from .views import (AgentViewSet, CollectionViewSet, MyListView, ObjectViewSet,
-                    SearchView, TermViewSet)
+                    SearchView)
 
 TYPE_MAP = (
     ('agent', Agent, AgentViewSet),
     ('collection', Collection, CollectionViewSet),
     ('object', Object, ObjectViewSet),
-    ('term', Term, TermViewSet),
+    # ('term', Term, TermViewSet),
 )
 
 STOP_WORDS = ["a", "an", "and", "are", "as", "at", "be", "but", "by", "for", "if",
@@ -174,7 +174,7 @@ class TestAPI(TestCase):
                 response.status_code, 200,
                 "View {}-detail in ViewSet {} did not return 200 for document {}".format(
                     basename, viewset, pk))
-            for uri in self.find_in_dict(response.data, "uri"):
+            for uri in list(filter(None, self.find_in_dict(response.data, "uri"))):
                 self.assertFalse(uri.endswith("/"))
             if basename in ["collection", "object"]:
                 self.assertTrue(isinstance(response.data["online"], bool))

--- a/api_formatter/tests.py
+++ b/api_formatter/tests.py
@@ -9,18 +9,19 @@ from django.urls import reverse
 from elasticsearch.helpers import streaming_bulk
 from elasticsearch_dsl import connections, utils
 from rac_es.documents import (Agent, BaseDescriptionComponent, Collection,
-                              Object)
+                              Object, Term)
 from rac_schemas import is_valid
 from rest_framework.test import APIRequestFactory
 
 from .view_helpers import date_string
 from .views import (AgentViewSet, CollectionViewSet, MyListView, ObjectViewSet,
-                    SearchView)
+                    SearchView, TermViewSet)
 
 TYPE_MAP = (
     ('agent', Agent, AgentViewSet),
     ('collection', Collection, CollectionViewSet),
     ('object', Object, ObjectViewSet),
+    ('term', Term, TermViewSet),
 )
 
 STOP_WORDS = ["a", "an", "and", "are", "as", "at", "be", "but", "by", "for", "if",

--- a/api_formatter/tests.py
+++ b/api_formatter/tests.py
@@ -258,7 +258,7 @@ class TestAPI(TestCase):
 
     def test_search(self):
         """Assert specific searches return expected number of results."""
-        for query_term, expected_count in [("rockefeller", 34), ("nelson", 5), ("cary reich", 2), ("", 175)]:
+        for query_term, expected_count in [("rockefeller", 34), ("nelson", 5), ("cary reich", 2), ("", 92)]:
             request = self.factory.get("{}?query={}".format(reverse("search-list"), query_term))
             response = SearchView.as_view(actions={"get": "list"}, basename="search")(request)
             self.assertEqual(response.data["count"], expected_count)

--- a/api_formatter/urls.py
+++ b/api_formatter/urls.py
@@ -3,13 +3,12 @@ from rest_framework.schemas import get_schema_view
 
 from .routers import RACRouter
 from .views import (AgentViewSet, CollectionViewSet, FacetView, ObjectViewSet,
-                    SearchView, TermViewSet)
+                    SearchView)
 
 router = RACRouter(trailing_slash=False)
 router.register(r'agents', AgentViewSet, basename='agent')
 router.register(r'collections', CollectionViewSet, basename='collection')
 router.register(r'objects', ObjectViewSet, basename='object')
-router.register(r'terms', TermViewSet, basename='term')
 router.register(r'search', SearchView, basename='search')
 
 schema_view = get_schema_view(

--- a/api_formatter/views.py
+++ b/api_formatter/views.py
@@ -4,7 +4,7 @@ from django_elasticsearch_dsl_drf.constants import SUGGESTER_TERM
 from django_elasticsearch_dsl_drf.pagination import LimitOffsetPagination
 from elasticsearch_dsl import A, Q
 from rac_es.documents import (Agent, BaseDescriptionComponent, Collection,
-                              Object)
+                              Object, Term)
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.status import HTTP_400_BAD_REQUEST
@@ -16,7 +16,8 @@ from .serializers import (AgentListSerializer, AgentSerializer,
                           AncestorsSerializer, CollectionHitSerializer,
                           CollectionListSerializer, CollectionSerializer,
                           FacetSerializer, ObjectListSerializer,
-                          ObjectSerializer, ReferenceSerializer)
+                          ObjectSerializer, ReferenceSerializer,
+                          TermListSerializer, TermSerializer)
 from .view_helpers import (FILTER_BACKENDS, FILTER_FIELDS,
                            NESTED_FILTER_FIELDS, NUMBER_LOOKUPS,
                            ORDERING_FIELDS, SEARCH_BACKENDS, SEARCH_FIELDS,
@@ -323,6 +324,32 @@ class ObjectViewSet(DocumentViewSet, AncestorMixin):
     search_fields = SEARCH_FIELDS
     search_nested_fields = SEARCH_NESTED_FIELDS
     ordering_fields = ORDERING_FIELDS
+
+
+class TermViewSet(DocumentViewSet):
+    """
+    list:
+    Returns a list of terms. Terms are controlled values describing topics,
+    geographic places or record formats.
+    retrieve:
+    Returns data about an individual term. Terms are controlled values describing
+    topics, geographic places or record formats.
+    """
+
+    document = Term
+    list_serializer = TermListSerializer
+    serializer = TermSerializer
+
+    filter_fields = {
+        "title": {"field": "title.keyword", "lookups": STRING_LOOKUPS, },
+        "term_type": {"field": "term_type", "lookups": STRING_LOOKUPS, },
+    }
+
+    search_fields = SEARCH_FIELDS + ("type",)
+
+    ordering_fields = {
+        "title": "title.keyword",
+    }
 
 
 class SearchView(DocumentViewSet):

--- a/api_formatter/views.py
+++ b/api_formatter/views.py
@@ -331,6 +331,7 @@ class TermViewSet(DocumentViewSet):
     list:
     Returns a list of terms. Terms are controlled values describing topics,
     geographic places or record formats.
+
     retrieve:
     Returns data about an individual term. Terms are controlled values describing
     topics, geographic places or record formats.

--- a/api_formatter/views.py
+++ b/api_formatter/views.py
@@ -4,7 +4,7 @@ from django_elasticsearch_dsl_drf.constants import SUGGESTER_TERM
 from django_elasticsearch_dsl_drf.pagination import LimitOffsetPagination
 from elasticsearch_dsl import A, Q
 from rac_es.documents import (Agent, BaseDescriptionComponent, Collection,
-                              Object, Term)
+                              Object)
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.status import HTTP_400_BAD_REQUEST
@@ -16,8 +16,7 @@ from .serializers import (AgentListSerializer, AgentSerializer,
                           AncestorsSerializer, CollectionHitSerializer,
                           CollectionListSerializer, CollectionSerializer,
                           FacetSerializer, ObjectListSerializer,
-                          ObjectSerializer, ReferenceSerializer,
-                          TermListSerializer, TermSerializer)
+                          ObjectSerializer, ReferenceSerializer)
 from .view_helpers import (FILTER_BACKENDS, FILTER_FIELDS,
                            NESTED_FILTER_FIELDS, NUMBER_LOOKUPS,
                            ORDERING_FIELDS, SEARCH_BACKENDS, SEARCH_FIELDS,

--- a/api_formatter/views.py
+++ b/api_formatter/views.py
@@ -326,33 +326,6 @@ class ObjectViewSet(DocumentViewSet, AncestorMixin):
     ordering_fields = ORDERING_FIELDS
 
 
-class TermViewSet(DocumentViewSet):
-    """
-    list:
-    Returns a list of terms. Terms are controlled values describing topics,
-    geographic places or record formats.
-
-    retrieve:
-    Returns data about an individual term. Terms are controlled values describing
-    topics, geographic places or record formats.
-    """
-
-    document = Term
-    list_serializer = TermListSerializer
-    serializer = TermSerializer
-
-    filter_fields = {
-        "title": {"field": "title.keyword", "lookups": STRING_LOOKUPS, },
-        "term_type": {"field": "term_type", "lookups": STRING_LOOKUPS, },
-    }
-
-    search_fields = SEARCH_FIELDS + ("type",)
-
-    ordering_fields = {
-        "title": "title.keyword",
-    }
-
-
 class SearchView(DocumentViewSet):
     """Performs search queries across agents, collections, objects and terms."""
     document = BaseDescriptionComponent


### PR DESCRIPTION
Fixes #188  and #187 

I think I've gone too far in removing `/terms` here? This is probably something that we'll want to add back in in the future when data is better, and maybe I shouldn't be trying to take all of this out, but just keep it out of the browseable API?

Also, as evidenced by the failing tests I'm having trouble extracting this gracefully. I'd appreciate some help focusing what I should be trying to do to solve issue #187 .