### PR TITLE
Add API documentation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,3 +7,4 @@ title: Getting Started with our Collections API
 description: Guide to using the Rockefeller Archive Center API to access our collections data.
 pages:
   - ["Getting Started with our Collections API", "index"]
+  - ["How to Use the API"]

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ type: "docs"
 category: reference and outreach
 tags: workflow
 
-title: Using our Collections API
+title: Getting Started with our Collections API
 description: Guide to using the Rockefeller Archive Center API to access our collections data.
 pages:
-  - ["Using our Collections API", "index"]
+  - ["Getting Started with our Collections API", "index"]

--- a/_config.yml
+++ b/_config.yml
@@ -7,4 +7,4 @@ title: Getting Started with our Collections API
 description: Guide to using the Rockefeller Archive Center API to access our collections data.
 pages:
   - ["Getting Started with our Collections API", "index"]
-  - ["How to Use the API"]
+  - ["How to Use the API", "use-api"]

--- a/_config.yml
+++ b/_config.yml
@@ -8,3 +8,4 @@ description: Guide to using the Rockefeller Archive Center API to access our col
 pages:
   - ["Getting Started with our Collections API", "index"]
   - ["How to Use the API", "use-api"]
+  - ["Endpoints and Parameters", "endpoints-parameters"]

--- a/endpoints-parameters.md
+++ b/endpoints-parameters.md
@@ -9,10 +9,10 @@ See the full OpenAPI schema at [https://api.rockarch.org/schema](https://api.roc
 
 ## Endpoints
 
-**Agents**: People, organizations or families.
-**Collections**: Intellectually significant groups of records.
-**Objects**: Intellectually significant groups of records that do not have children.
-**Terms**: Controlled values describing topics, geographic places or record formats.
+**Agents**: People, organizations or families.  
+**Collections**: Intellectually significant groups of records.  
+**Objects**: Intellectually significant groups of records that do not have children.  
+**Terms**: Controlled values describing topics, geographic places or record formats.  
 
 | Endpoint | Description |
 |------|------|

--- a/endpoints-parameters.md
+++ b/endpoints-parameters.md
@@ -1,0 +1,47 @@
+---
+layout: docs
+title:  "Endpoints and Parameters"
+---
+
+Using the available endpoints and their parameters, you can construct queries to get data back from the API. 
+
+See the full OpenAPI schema at [https://api.rockarch.org/schema](https://api.rockarch.org/schema) to see how our API is structured and understand the data.
+
+## Endpoints
+
+| Endpoint | Description |
+|------|------|
+|/agents|Returns a list of agents. Agents are people, organizations or families.|
+|/agents/{id}|Returns data about an individual agent.|
+|/collections|Returns a list of collections. Collections are intellectually significant groups of records.|
+|/collections/{id}|Returns data about an individual collection.|
+|/collections/{id}/ancestors|Returns the ancestors of a collection.|
+|/collections/{id}/children|Returns the children of a collection.|
+|/collections/{id}/minimap|Returns data about where search hits are located within a collection.|
+|/objects|Returns a list of objects. Objects are intellectually significant groups of records that do not have children.|
+|/objects/{id}|Returns data about an individual object.|
+|/objects/{id}/ancestors|Returns the ancestors of an object.|
+|/terms|Returns a list of terms. Terms are controlled values describing topics, geographic places or record formats.|
+|/terms/{id}|Returns data about an individual term.|
+|/search|Performs search queries across agents, collections, objects and terms.|
+|/search/{id}|Performs search queries across a specific agent, collection, object or term.
+|/schema/|Returns the OpenAPI schema for the RAC API.|
+
+## Parameters
+Use our [browsable API](https://api.rockarch.org) to see which parameters are available for which endpoints. For example, [https://api.rockarch.org/collections](https://api.rockarch.org/collections) lists the filter and sort fields, or parameters, that are available for that endpoint at the top of the webpage.
+
+| Parameter | Description | Example |
+|------|------|------|
+|limit|Number of results to return per page.|limit=50|
+|offset|Number of results to return per page.|offset=50|
+|id|Unique identifier. The id is used in an endpoint path to point to a specific collection, object, agents, etc.|/collections/2HnhFZfibK6SVVu86skz3k|
+|title|Filter or sort results by title.|title=world health organization|
+|start_date|Filter results by start date.|start_date=1932|
+|end_date|Filter results by start date.|end_date=1975|
+|category|Filter results by category term, including `person`, `collection`, or `organization`|category=person|
+|subject|Filter results by subject/topic term|subject=public health|
+|creator|Filter results by creator. Creators are the people, organizations, and families responsible for creating the records.|creator=adams, lillian|
+|online|Filter results by objects that are digital and available to view online.|online=true|
+|genre|Filters results by genre/format term, including `documents`, `photographs`, `moving image`, and `audio`.|genre=moving image|
+|query|Query for full-text search|query=yellow fever|
+|sort|Sort results by title, start_date, end_date, or type. By default the named property will be sorted ascending. Descending order can be achieved by appending an en dash (`-`) to the start of the property.|sort=title|

--- a/endpoints-parameters.md
+++ b/endpoints-parameters.md
@@ -9,19 +9,24 @@ See the full OpenAPI schema at [https://api.rockarch.org/schema](https://api.roc
 
 ## Endpoints
 
+**Agents**: People, organizations or families.
+**Collections**: Intellectually significant groups of records.
+**Objects**: Intellectually significant groups of records that do not have children.
+**Terms**: Controlled values describing topics, geographic places or record formats.
+
 | Endpoint | Description |
 |------|------|
-|/agents|Returns a list of agents. Agents are people, organizations or families.|
+|/agents|Returns a list of agents.|
 |/agents/{id}|Returns data about an individual agent.|
-|/collections|Returns a list of collections. Collections are intellectually significant groups of records.|
+|/collections|Returns a list of collections.|
 |/collections/{id}|Returns data about an individual collection.|
 |/collections/{id}/ancestors|Returns the ancestors of a collection.|
-|/collections/{id}/children|Returns the children of a collection.|
+|/collections/{id}/children|Returns the children of a collection. Children of collections can be collections or objects.|
 |/collections/{id}/minimap|Returns data about where search hits are located within a collection.|
-|/objects|Returns a list of objects. Objects are intellectually significant groups of records that do not have children.|
+|/objects|Returns a list of objects.|
 |/objects/{id}|Returns data about an individual object.|
 |/objects/{id}/ancestors|Returns the ancestors of an object.|
-|/terms|Returns a list of terms. Terms are controlled values describing topics, geographic places or record formats.|
+|/terms|Returns a list of terms.|
 |/terms/{id}|Returns data about an individual term.|
 |/search|Performs search queries across agents, collections, objects and terms.|
 |/search/{id}|Performs search queries across a specific agent, collection, object or term.

--- a/endpoints-parameters.md
+++ b/endpoints-parameters.md
@@ -45,3 +45,13 @@ Use our [browsable API](https://api.rockarch.org) to see which parameters are av
 |genre|Filters results by genre/format term, including `documents`, `photographs`, `moving image`, and `audio`.|genre=moving image|
 |query|Query for full-text search|query=yellow fever|
 |sort|Sort results by title, start_date, end_date, or type. By default the named property will be sorted ascending. Descending order can be achieved by appending an en dash (`-`) to the start of the property.|sort=title|
+
+### Refining dates
+Specify dates and date ranges by appending conditions to the start and end date parameters separated by a double underscore: `__`. For example, `start_date__gte=1940&end_date__lt=1950` includes all dates from 1940 to 1949.
+
+| Parameter condition | Description |
+|------|------|
+|gt|greater than|
+|lt|less than|
+|gte|greater than or equal to|
+|lte|less than or equal to|

--- a/index.md
+++ b/index.md
@@ -1,4 +1,42 @@
 ---
 layout: docs
-title:  "Using our Collections API"
+title:  "Getting Started with our Collections API"
 ---
+
+## What is an API? 
+
+An API (Application Programming Interface) is a set of instructions that tells one software application how to "talk to", or transmit data, to another. If you have used [DIMES](https://dimes.rockarch.org/), our site to enable search and access to our collections, you have seen our API in action. For example, when you initiate a search for something in DIMES, your browser makes a request to the API, which delivers the data as the search results. With the API, you can bypass the website interface and instead send requests directly to get the data. With direct access, you can explore the data in different ways and build new things.
+
+## Who can use our API? 
+
+Anyone can use it! We have made it publicly available to enable people like you to freely access the data. There is no sign up or authentication required, although you may want to browse this documentation, which shows you have to make requests. [The best place to start is...]
+
+### What is the data and where does it come from? 
+
+Our archival holdings are arranged and described by Rockefeller Archive Center archivists to make them accessible and facilitate use by providing information about their content and context. Archivists create descriptive information about: 
+
+1. Archival records
+2. Agents, who are records creators and other people, organizations, and families related to the records
+3. Relevant biographical, historical, or administrative activities
+4. The relationships between these records, agents and activities.
+
+All of this information is managed in its own system, and it is made available in the API. The API also includes data used specifically in the DIMES website that improves search and discovery on the site.
+
+Learn more about what data is available by [browsing the available endpoints](#) *[add link]*, or points of entry to communicate with the API about specific resources.
+
+### Licensing 
+
+This data is released under a Creative Commons Zero (CC0) public domain dedication. See our [full licensing statement](https://docs.rockarch.org/archival-description-license/) for specific license terms as well as best practices for repurposing this data.
+
+## What can I do with it? 
+
+You can use the API to get our collections data, and you can use that data in any way you like. Build applications, visualize and analyze data in new ways, search and browse, make new connections. 
+
+[Include some example use case ideas, and link to use case blog post/s]
+
+## Where can I report an issue?
+
+Is something not working as expected? Please let us know! You can either file an issue in the [API GitHub repository](https://github.com/RockefellerArchiveCenter/argo), or email us at [give an email]
+
+## Create something? Share with us! 
+Keep in touch. We'd love to hear about how you're using our data. [Find us on Twitter](https://twitter.com/rockarch_org) or email [give an email]. 

--- a/index.md
+++ b/index.md
@@ -17,6 +17,9 @@ With the API, you can bypass the website interface and instead send requests dir
 
 Anyone can use it! We have made it publicly available for people like you to freely access. There is no sign up or authentication required.
 
+### Licensing
+Our data is released under a Creative Commons Zero (CC0) public domain dedication. See our [full licensing statement](https://docs.rockarch.org/archival-description-license/) for specific license terms as well as best practices for repurposing this data.
+
 ## What is the data and where does it come from? 
 
 Our archival holdings are arranged and described by Rockefeller Archive Center archivists to make them accessible and facilitate use by providing information about their content and context. Archivists create descriptive information about: 
@@ -29,10 +32,6 @@ Our archival holdings are arranged and described by Rockefeller Archive Center a
 All of this information is managed in its own system and made available via the API. The API also includes data used specifically in the DIMES website to improve search and discovery on the site.
 
 Learn more about what data is available by [browsing the available API endpoints](https://api.rockarch.org), or points of entry to communicate with the API.
-
-## Licensing 
-
-This data is released under a Creative Commons Zero (CC0) public domain dedication. See our [full licensing statement](https://docs.rockarch.org/archival-description-license/) for specific license terms as well as best practices for repurposing this data.
 
 ## What can I do with the API? 
 

--- a/index.md
+++ b/index.md
@@ -9,34 +9,34 @@ An API (Application Programming Interface) is a set of instructions that tells o
 
 ## Who can use our API? 
 
-Anyone can use it! We have made it publicly available to enable people like you to freely access the data. There is no sign up or authentication required, although you may want to browse this documentation, which shows you how to make requests. [The best place to start is...]
+Anyone can use it! We have made it publicly available to enable people like you to freely access the data. There is no sign up or authentication required, although you may want to browse this documentation, which shows you how to make requests.
 
 ### What is the data and where does it come from? 
 
 Our archival holdings are arranged and described by Rockefeller Archive Center archivists to make them accessible and facilitate use by providing information about their content and context. Archivists create descriptive information about: 
 
-1. Archival records
-2. Agents, who are records creators and other people, organizations, and families related to the records
-3. Relevant biographical, historical, or administrative activities
+1. Archival records.
+2. Agents, who are records creators and other people, organizations, and families related to the records.
+3. Relevant biographical, historical, or administrative activities.
 4. The relationships between these records, agents and activities.
 
 All of this information is managed in its own system and made available via the API. The API also includes data used specifically in the DIMES website to improve search and discovery on the site.
 
-Learn more about what data is available by [browsing the available endpoints](#) *[add link]*, or points of entry to communicate with the API about specific resources.
+Learn more about what data is available by [browsing the available API endpoints](https://api.rockarch.org), or points of entry to communicate with the API about specific resources.
 
 ### Licensing 
 
 This data is released under a Creative Commons Zero (CC0) public domain dedication. See our [full licensing statement](https://docs.rockarch.org/archival-description-license/) for specific license terms as well as best practices for repurposing this data.
 
-## What can I do with it? 
+## What can I do with the API? 
 
-You can use the API to get our collections data, and you can use that data in any way you like. Build applications, visualize and analyze data in new ways, search and browse, make new connections. 
+You can use the API to get our collections data, and you can use that data in any way you like. Build applications, visualize and analyze data in new ways, search and browse, and generally make new connections. 
 
-[Include some example use case ideas, and link to use case blog post/s]
+For an example of what is possible, check out our blog for [an experimental example that uses the API](#) to explore collections through various visualizations. 
 
 ## Where can I report an issue?
 
-Is something not working as expected? Please let us know! You can either file an issue in the [API GitHub repository](https://github.com/RockefellerArchiveCenter/argo), or email us at [give an email]
+Is something not working as expected? Please let us know! You can either file an issue in the [API GitHub repository](https://github.com/RockefellerArchiveCenter/argo), or email us at archive@rockarch.org.
 
 ## Create something? Share with us! 
-Keep in touch. We'd love to hear about how you're using our data. [Find us on Twitter](https://twitter.com/rockarch_org) or email [give an email]. 
+Keep in touch. We'd love to hear about how you're using our data. [Find us on Twitter](https://twitter.com/rockarch_org) or email archive@rockarch.org. 

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ title:  "Getting Started with our Collections API"
 
 ## What is an API? 
 
-An API (Application Programming Interface) is a set of instructions that tells one software application how to "talk to", or transmit data, to another. If you have used [DIMES](https://dimes.rockarch.org/), our site to enable search and access to our collections, you have seen our API in action. For example, when you initiate a search for something in DIMES, your browser makes a request to the API, which delivers the data as the search results. 
+An API (Application Programming Interface) is a set of instructions that tells one software application how to "talk to", or transmit data, to another. If you have used [DIMES](https://dimes.rockarch.org/), our site to enable search and access to our collections, you have used an API. For example, when you initiate a search for something in DIMES, your browser makes a request to the API, which delivers the data as the search results. 
 
 With the API, you can bypass the website interface and instead send requests directly to get the data. With this direct access, you can explore the data in different ways and build new things.
 
@@ -32,7 +32,7 @@ This data is released under a Creative Commons Zero (CC0) public domain dedicati
 
 ## What can I do with the API? 
 
-You can use the API to get our collections data, and you can use that data in any way you like. Build applications, visualize and analyze data in new ways, search and browse, and generally make new connections. 
+You can use the API to get our collections data, and you can use that data in any way you like: build applications, visualize and analyze data in new ways, search and browse, and generally make new connections. 
 
 Example project: [Read our blog post](#) about an experiment to explore Rockefeller Archive Center collections through various visualizations. 
 

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ title:  "Getting Started with our Collections API"
 
 ## How do I use this guide?
 
-This guide contains some definitions, context, examples, and technical documentation to get you started working with our collections data API. We encourage folks from all experience levels to explore and feel free to skip to the sections that are most useful for you.
+This guide contains some definitions, context, examples, and technical documentation to get you started working with our collections data API. We encourage folks from all experience levels to explore and feel free to skip to the sections that are useful for you.
 
 ## What is an API? 
 

--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 ---
 layout: docs
-title:  "Getting Started with our Collections API"
+title:  "Getting Started with Our Collections API"
 ---
 
 ## How do I use this guide?

--- a/index.md
+++ b/index.md
@@ -3,9 +3,13 @@ layout: docs
 title:  "Getting Started with our Collections API"
 ---
 
+## How do I use this guide?
+
+This guide contains some definitions, context, examples, and technical documentation to get you started working with our collections data API. We encourage folks from all experience levels to explore and feel free to skip to the sections that are most useful for you.
+
 ## What is an API? 
 
-An API (Application Programming Interface) is a set of instructions that tells one software application how to "talk to", or transmit data, to another. If you have used [DIMES](https://dimes.rockarch.org/), our site to enable search and access to our collections, you have used an API. For example, when you initiate a search for something in DIMES, your browser makes a request to the API, which delivers the data as the search results. 
+An API (Application Programming Interface) is a set of instructions that tells one software application how to "talk to", or transmit data, to another. If you have used [DIMES](https://dimes.rockarch.org/), the Rockefeller Archive Center's site to enable search and access to our collections, you have used an API. For example, when you initiate a search for something in DIMES, your browser makes a request to the API, which delivers the data as the search results. 
 
 With the API, you can bypass the website interface and instead send requests directly to get the data. With this direct access, you can explore the data in different ways and build things.
 
@@ -34,7 +38,7 @@ This data is released under a Creative Commons Zero (CC0) public domain dedicati
 
 You can use the API to get our collections data, and you can use that data in any way you like: build applications, visualize and analyze data in new ways, search and browse, and generally make connections. 
 
-Example project: [Read our blog post](#) about an experiment to explore Rockefeller Archive Center collections through various visualizations. 
+Example project: [Read our blog post](https://blog.rockarch.org/using-the-rac-collections-api-to-create-visualizations) about an experiment to explore Rockefeller Archive Center collections through various visualizations. 
 
 ## Where can I report an issue?
 
@@ -42,3 +46,6 @@ Please let us know if something isn't working as expected! You can either file a
 
 ## Create something? Share with us! 
 Keep in touch. We'd love to hear about how you're using our data. [Find us on Twitter](https://twitter.com/rockarch_org) or email archive@rockarch.org. 
+
+## Bulk data download 
+You can also access [exports of our public collections data](https://github.com/RockefellerArchiveCenter/data) on GitHub. The data is generally exported on a bi-monthly basis.

--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ title:  "Getting Started with our Collections API"
 
 An API (Application Programming Interface) is a set of instructions that tells one software application how to "talk to", or transmit data, to another. If you have used [DIMES](https://dimes.rockarch.org/), our site to enable search and access to our collections, you have used an API. For example, when you initiate a search for something in DIMES, your browser makes a request to the API, which delivers the data as the search results. 
 
-With the API, you can bypass the website interface and instead send requests directly to get the data. With this direct access, you can explore the data in different ways and build new things.
+With the API, you can bypass the website interface and instead send requests directly to get the data. With this direct access, you can explore the data in different ways and build things.
 
 ## Who can use our API? 
 
@@ -32,7 +32,7 @@ This data is released under a Creative Commons Zero (CC0) public domain dedicati
 
 ## What can I do with the API? 
 
-You can use the API to get our collections data, and you can use that data in any way you like: build applications, visualize and analyze data in new ways, search and browse, and generally make new connections. 
+You can use the API to get our collections data, and you can use that data in any way you like: build applications, visualize and analyze data in new ways, search and browse, and generally make connections. 
 
 Example project: [Read our blog post](#) about an experiment to explore Rockefeller Archive Center collections through various visualizations. 
 

--- a/index.md
+++ b/index.md
@@ -5,11 +5,13 @@ title:  "Getting Started with our Collections API"
 
 ## What is an API? 
 
-An API (Application Programming Interface) is a set of instructions that tells one software application how to "talk to", or transmit data, to another. If you have used [DIMES](https://dimes.rockarch.org/), our site to enable search and access to our collections, you have seen our API in action. For example, when you initiate a search for something in DIMES, your browser makes a request to the API, which delivers the data as the search results. With the API, you can bypass the website interface and instead send requests directly to get the data. With direct access, you can explore the data in different ways and build new things.
+An API (Application Programming Interface) is a set of instructions that tells one software application how to "talk to", or transmit data, to another. If you have used [DIMES](https://dimes.rockarch.org/), our site to enable search and access to our collections, you have seen our API in action. For example, when you initiate a search for something in DIMES, your browser makes a request to the API, which delivers the data as the search results. 
+
+With the API, you can bypass the website interface and instead send requests directly to get the data. With this direct access, you can explore the data in different ways and build new things.
 
 ## Who can use our API? 
 
-Anyone can use it! We have made it publicly available to enable people like you to freely access the data. There is no sign up or authentication required, although you may want to browse this documentation, which shows you how to make requests.
+Anyone can use it! We have made it publicly available for people like you to freely access. There is no sign up or authentication required.
 
 ### What is the data and where does it come from? 
 
@@ -22,7 +24,7 @@ Our archival holdings are arranged and described by Rockefeller Archive Center a
 
 All of this information is managed in its own system and made available via the API. The API also includes data used specifically in the DIMES website to improve search and discovery on the site.
 
-Learn more about what data is available by [browsing the available API endpoints](https://api.rockarch.org), or points of entry to communicate with the API about specific resources.
+Learn more about what data is available by [browsing the available API endpoints](https://api.rockarch.org), or points of entry to communicate with the API.
 
 ### Licensing 
 
@@ -32,11 +34,11 @@ This data is released under a Creative Commons Zero (CC0) public domain dedicati
 
 You can use the API to get our collections data, and you can use that data in any way you like. Build applications, visualize and analyze data in new ways, search and browse, and generally make new connections. 
 
-For an example of what is possible, check out our blog for [an experimental example that uses the API](#) to explore collections through various visualizations. 
+Example project: [Read our blog post](#) about an experiment to explore Rockefeller Archive Center collections through various visualizations. 
 
 ## Where can I report an issue?
 
-Is something not working as expected? Please let us know! You can either file an issue in the [API GitHub repository](https://github.com/RockefellerArchiveCenter/argo), or email us at archive@rockarch.org.
+Please let us know if something isn't working as expected! You can either file an issue in the [GitHub repository](https://github.com/RockefellerArchiveCenter/argo), or email us at archive@rockarch.org.
 
 ## Create something? Share with us! 
 Keep in touch. We'd love to hear about how you're using our data. [Find us on Twitter](https://twitter.com/rockarch_org) or email archive@rockarch.org. 

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ title:  "Getting Started with our Collections API"
 
 ## How do I use this guide?
 
-This guide contains some definitions, context, examples, and technical documentation to get you started working with our collections data API. We encourage folks from all experience levels to explore and feel free to skip to the sections that are useful for you.
+This guide contains some definitions, context, examples, and technical documentation to get you started working with our collections data API. We encourage folks from all experience levels to explore, and you should feel free to skip to the sections that are useful for you.
 
 ## What is an API? 
 
@@ -27,7 +27,7 @@ Our archival holdings are arranged and described by Rockefeller Archive Center a
 1. Archival records.
 2. Agents, who are records creators and other people, organizations, and families related to the records.
 3. Relevant biographical, historical, or administrative activities.
-4. The relationships between these records, agents and activities.
+4. The relationships between these records, agents, and activities.
 
 All of this information is managed in its own system and made available via the API. The API also includes data used specifically in the DIMES website to improve search and discovery on the site.
 

--- a/index.md
+++ b/index.md
@@ -9,7 +9,7 @@ An API (Application Programming Interface) is a set of instructions that tells o
 
 ## Who can use our API? 
 
-Anyone can use it! We have made it publicly available to enable people like you to freely access the data. There is no sign up or authentication required, although you may want to browse this documentation, which shows you have to make requests. [The best place to start is...]
+Anyone can use it! We have made it publicly available to enable people like you to freely access the data. There is no sign up or authentication required, although you may want to browse this documentation, which shows you how to make requests. [The best place to start is...]
 
 ### What is the data and where does it come from? 
 
@@ -20,7 +20,7 @@ Our archival holdings are arranged and described by Rockefeller Archive Center a
 3. Relevant biographical, historical, or administrative activities
 4. The relationships between these records, agents and activities.
 
-All of this information is managed in its own system, and it is made available in the API. The API also includes data used specifically in the DIMES website that improves search and discovery on the site.
+All of this information is managed in its own system and made available via the API. The API also includes data used specifically in the DIMES website to improve search and discovery on the site.
 
 Learn more about what data is available by [browsing the available endpoints](#) *[add link]*, or points of entry to communicate with the API about specific resources.
 

--- a/index.md
+++ b/index.md
@@ -13,7 +13,7 @@ With the API, you can bypass the website interface and instead send requests dir
 
 Anyone can use it! We have made it publicly available for people like you to freely access. There is no sign up or authentication required.
 
-### What is the data and where does it come from? 
+## What is the data and where does it come from? 
 
 Our archival holdings are arranged and described by Rockefeller Archive Center archivists to make them accessible and facilitate use by providing information about their content and context. Archivists create descriptive information about: 
 
@@ -26,7 +26,7 @@ All of this information is managed in its own system and made available via the 
 
 Learn more about what data is available by [browsing the available API endpoints](https://api.rockarch.org), or points of entry to communicate with the API.
 
-### Licensing 
+## Licensing 
 
 This data is released under a Creative Commons Zero (CC0) public domain dedication. See our [full licensing statement](https://docs.rockarch.org/archival-description-license/) for specific license terms as well as best practices for repurposing this data.
 

--- a/use-api.md
+++ b/use-api.md
@@ -14,7 +14,7 @@ Get started with your favorite API tool or script. We do not require an API key.
 
 
 ## Quick start 
-Data is accessed through GET requests using API endpoints. For a list of available endpoints, see the [endpoints and parameters](#endpoints-and-parameters) section of this document.
+Data is accessed through GET requests using API endpoints. For a list of available endpoints, see the [endpoints and parameters](/argo/endpoints-parameters) section of this document.
 
 Example 1:
 Use the `/collections` endpoint to get a list of all of our archival collections, which are intellectually significant groups of records:
@@ -29,7 +29,7 @@ Get data about one specific collection, replacing {id} with the collection's ide
 ```
 GET https://api.rockarch.org/collections/{id}
 ```
-See what a response looks like in the browseable API by opening the link in your browser: [https://api.rockarch.org/collections/H45i6yf7MUHuaRwQVupvg5](https://api.rockarch.org/collections/H45i6yf7MUHuaRwQVupvg5).
+See what a response looks like in the browsable API by opening the link in your browser: [https://api.rockarch.org/collections/H45i6yf7MUHuaRwQVupvg5](https://api.rockarch.org/collections/H45i6yf7MUHuaRwQVupvg5).
 
 Example 3:
 Use the `/objects` endpoint and `online` parameter to get data for all archival objects that have digital versions available. Objects are defined as intellectually significant groups of records in a collection that do not have children:
@@ -56,51 +56,6 @@ Example: get the **second** page of agent records consisting of **10** records:
 ```
 GET https://api.rockarch.org/agents?limit=10&offset=10
 ```
-
-## Endpoints and parameters
-
- Using the available endpoints and their parameters, you can construct queries to get data back from the API. 
-
-See the full OpenAPI schema at [https://api.rockarch.org/schema](https://api.rockarch.org/schema) to see how our API is structured and understand the data.
-
-### Endpoints
-
-| Endpoint | Description |
-|------|------|
-|/agents|Returns a list of agents. Agents are people, organizations or families.|
-|/agents/{id}|Returns data about an individual agent.|
-|/collections|Returns a list of collections. Collections are intellectually significant groups of records.|
-|/collections/{id}|Returns data about an individual collection.|
-|/collections/{id}/ancestors|Returns the ancestors of a collection.|
-|/collections/{id}/children|Returns the children of a collection.|
-|/collections/{id}/minimap|Returns data about where search hits are located within a collection.|
-|/objects|Returns a list of objects. Objects are intellectually significant groups of records that do not have children.|
-|/objects/{id}|Returns data about an individual object.|
-|/objects/{id}/ancestors|Returns the ancestors of an object.|
-|/terms|Returns a list of terms. Terms are controlled values describing topics, geographic places or record formats.|
-|/terms/{id}|Returns data about an individual term.|
-|/search|Performs search queries across agents, collections, objects and terms.|
-|/search/{id}|Performs search queries across a specific agent, collection, object or term.
-|/schema/|Returns the OpenAPI schema for the RAC API.|
-
-### Parameters
-Use our [browseable API](https://api.rockarch.org) to see which parameters are available for which endpoints. For example, [https://api.rockarch.org/collections](https://api.rockarch.org/collections) lists the filter and sort fields, or parameters, that are available for that endpoint at the top of the webpage.
-
-| Parameter | Description | Example |
-|------|------|------|
-|limit|Number of results to return per page.|limit=50|
-|offset|Number of results to return per page.|offset=50|
-|id|Unique identifier. The id is used in an endpoint path to point to a specific collection, object, agents, etc.|/collections/2HnhFZfibK6SVVu86skz3k|
-|title|Filter or sort results by title.|title=world health organization|
-|start_date|Filter results by start date.|start_date=1932|
-|end_date|Filter results by start date.|end_date=1975|
-|category|Filter results by category term, including `person`, `collection`, or `organization`|category=person|
-|subject|Filter results by subject/topic term|subject=public health|
-|creator|Filter results by creator. Creators are the people, organizations, and families responsible for creating the records.|creator=adams, lillian|
-|online|Filter results by objects that are digital and available to view online.|online=true|
-|genre|Filters results by genre/format term, including `documents`, `photographs`, `moving image`, and `audio`.|genre=moving image|
-|query|Query for full-text search|query=yellow fever|
-|sort|Sort results by title, start_date, end_date, or type. By default the named property will be sorted ascending. Descending order can be achieved by appending an en dash (`-`) to the start of the property.|sort=title|
 
 ## Example queries
 

--- a/use-api.md
+++ b/use-api.md
@@ -51,7 +51,7 @@ Use the `/search` endpoint to return the number of search matches for the query 
 https://api.rockarch.org/search?&query=agriculture&category=collection&genre=photographs&start_date__gte=1940&end_date__lte=1950
 ```
 
-**Note**: Appending `__gte` and `__lte` to the date parameters function as `greater than or equal to` and `less than or equal to`, allowing us to include any start and end dates in this decade instead of limiting ourselves to specific start and end dates. Similarly, `gt`= greater than and `lt`= less than.
+**Note**: As documented in the [parameters section](/argo/endpoints-parameters#parameters), appending `__gte` and `__lte` to the date parameters function as `greater than or equal to` and `less than or equal to`, allowing us to include any start and end dates in this decade instead of limiting ourselves to specific start and end dates.
 
 ### Example 5: Minimap
 Use the `/minimap` endpoint to return collections and objects with search hits for the query term "agriculture" within the Ford Foundation records collection:

--- a/use-api.md
+++ b/use-api.md
@@ -24,7 +24,7 @@ GET https://api.rockarch.org/collections
 ```
 
 Example 2:
-Get data about one specific collection, replacing {id} with the collection's identifier (example id: `H45i6yf7MUHuaRwQVupvg5`):
+Get data about one specific collection, replacing {id} with the collection's identifier (example id: `H45i6yf7MUHuaRwQVupvg5`). Collection identifiers can be found in the `/collections` or `/search` endpoints as the URI value of a collection. They can also be found in DIMES URLs, since DIMES uses the API. For example: `https://dimes.rockarch.org/collections/H45i6yf7MUHuaRwQVupvg5`: 
 
 ```
 GET https://api.rockarch.org/collections/{id}

--- a/use-api.md
+++ b/use-api.md
@@ -2,19 +2,19 @@
 layout: docs
 title:  "How to Use the API"
 ---
-
 ## Access methods 
 The API is public and available for GET requests at [https://api.rockarch.org](https://api.rockarch.org). 
 
 Get started with your favorite API tool or script. We do not require an API key.
 
-- If you are new to scripting or working with APIs, consider using a tool like [Hoppscotch](https://hoppscotch.io/) or [Postman](https://www.postman.com/).
 - Browse the API online at [https://api.rockarch.org](https://api.rockarch.org).
+- If you are new to scripting or working with APIs, consider using a tool like [Hoppscotch](https://hoppscotch.io/) or [Postman](https://www.postman.com/).
 - We provide an [API client](https://pypi.org/project/rac-api-client/) to simplify requests if you are writing Python scripts.
 
-
 ## Quick start 
-Data is accessed through GET requests using API endpoints. For a list of available endpoints, see the [endpoints and parameters](/argo/endpoints-parameters) section of this document.
+The best way to learn what is available via the API is to start making API requests and exploring what comes back, whether in the [browsable API](https://api.rockarch.org) with URLs or using another interface. Data is accessed through GET requests using API endpoints. For a list of available endpoints, see the [endpoints and parameters](/argo/endpoints-parameters) section of this document.
+
+This section includes some basic examples to show you how to construct queries and start exploring.
 
 ### Example 1: Get all collections
 Use the `/collections` endpoint to get a list of all of our archival collections, which are intellectually significant groups of records:
@@ -134,6 +134,3 @@ Result:
 ```
 ['Rockefeller, David (1915-2017)', 'Knowles, John H. (1926-1979)', 'Ford Foundation', 'Reich, Cary', 'Rockefeller Foundation', 'John and Mary R. Markle Foundation', 'Rockefeller, Nelson A. (Nelson Aldrich)', 'Foundation for Child Development', 'Linden, Patricia', 'Asian Cultural Council', 'Rockefeller, John D., III (John Davison), 1906-1978', 'Rockefeller, Laurance Spelman', 'Arts in Education Program (U.S.)', 'National Committee on United States-China Relations', 'JDR 3rd Fund', 'Downtown Lower Manhattan Association', 'Henry Luce Foundation', 'Rockefeller, John D., Jr. (John Davison), 1874-1960', 'Grant, W. T. (William Thomas)', 'Knight Foundation', 'William T. Grant Foundation']
 ```
-
-## Bulk download 
-You can access [exports of our public collections data](https://github.com/RockefellerArchiveCenter/data) on GitHub. The data is generally exported on a bi-monthly basis.

--- a/use-api.md
+++ b/use-api.md
@@ -114,5 +114,27 @@ https://api.rockarch.org/search?&query=agriculture&category=collection&genre=pho
 https://api.rockarch.org/collections/2HnhFZfibK6SVVu86skz3k/minimap?query=agriculture
 ```
 
+3. Write a Python script using the [rac_api_client](https://pypi.org/project/rac-api-client/) to identify the creators (people or organizations) of collections that contain keyword search matches for "green revolution". The `/search` endpoint performs search queries across agents, collections, objects and terms. 
+
+```
+# import rac_api_client module
+from rac_api_client import Client
+
+# search across agents, collections, objects and terms for "green revolution"
+client = Client()
+response = client.get("/search", params={"query": "green revolution"})
+
+# create a list of creators (people or organization) of collections that contain search matches for the query
+creator_list = []
+
+for collection in response["results"]:
+  for creator in (collection["creators"]):
+    if creator not in creator_list:
+      creator_list.append(creator)
+
+# print list of creators
+print(creator_list)
+```
+
 ## Bulk download 
 You can access [exports of our public collections data](https://github.com/RockefellerArchiveCenter/data) on GitHub. The data is generally exported on a bi-monthly basis.

--- a/use-api.md
+++ b/use-api.md
@@ -44,6 +44,22 @@ Note that `online` is a query parameter. By convention, these are included after
 https://api.rockarch.org/objects?online=true&start_date=1950
 ```
 
+### Example 4: Search
+Use the `/search` endpoint to return the number of search matches for the query term "agriculture" that are in collections and have been categorized as photographs with dates between 1940 and 1950:
+
+```
+https://api.rockarch.org/search?&query=agriculture&category=collection&genre=photographs&start_date__gte=1940&end_date__lte=1950
+```
+
+**Note**: Appending `__gte` and `__lte` to the date parameters function as `greater than or equal to` and `less than or equal to`, allowing us to include any start and end dates in this decade instead of limiting ourselves to specific start and end dates. Similarly, `gt`= greater than and `lt`= less than.
+
+### Example 5: Minimap
+Use the `/minimap` endpoint to return collections and objects with search hits for the query term "agriculture" within the Ford Foundation records collection:
+
+```
+https://api.rockarch.org/collections/2HnhFZfibK6SVVu86skz3k/minimap?query=agriculture
+```
+
 ## Understanding the data that comes back 
 We provide [JSON](https://www.json.org/json-en.html)-formatted data.
 
@@ -57,30 +73,10 @@ Example: get the **second** page of agent records consisting of **10** records:
 GET https://api.rockarch.org/agents?limit=10&offset=10
 ```
 
-## Example queries
-
-### Using URLS
-
-#### Example 1: Search
-Use the `/search` endpoint to return the number of search matches for the query term "agriculture" that are in collections and have been categorized as photographs with dates between 1940 and 1950:
-
-```
-https://api.rockarch.org/search?&query=agriculture&category=collection&genre=photographs&start_date__gte=1940&end_date__lte=1950
-```
-
-**Note**: Appending `__gte` and `__lte` to the date parameters function as `greater than or equal to` and `less than or equal to`, allowing us to include any start and end dates in this decade instead of limiting ourselves to specific start and end dates. Similarly, `gt`= greater than and `lt`= less than.
-
-#### Example 2: Minimap
-Use the `/minimap` endpoint to return collections and objects with search hits for the query term "agriculture" within the Ford Foundation records collection:
-
-```
-https://api.rockarch.org/collections/2HnhFZfibK6SVVu86skz3k/minimap?query=agriculture
-```
-
-### Using the API client with Python
+## Using the API client with Python
 Example Python scripts that uses the [RAC API client](https://pypi.org/project/rac-api-client/):
 
-#### Example 1: Size of collection
+### Example 1: Size of collection
 Find out the physical size (called extent) of the Social Science Research Council records collection in the archives.
 
 ```python
@@ -107,7 +103,7 @@ Social Science Research Council records
 509.06 Cubic Feet
 ```
 
-#### Example 2: Collection creators
+### Example 2: Collection creators
 Identify the creators of collections that contain keyword search matches for "public television". The `/search` endpoint performs search queries across agents, collections, objects, and terms.
 
 Creators are the people, organizations, or families responsible for creating the records. Terms are controlled values describing topics, geographic places, or record formats.

--- a/use-api.md
+++ b/use-api.md
@@ -129,6 +129,8 @@ Example Python scripts that uses the [RAC API client](https://pypi.org/project/r
 Find out the physical size (called extent) of the Social Science Research Council records collection in the archives.
 
 ```python
+# import rac_api_client module
+from rac_api_client import Client
 
 # get the collection data about the Social Science Research Council 
 # records using the collection id.
@@ -156,7 +158,6 @@ Identify the creators of collections that contain keyword search matches for "pu
 Creators are the people, organizations, or families responsible for creating the records. Terms are controlled values describing topics, geographic places, or record formats.
 
 ```python
-
 # import rac_api_client module
 from rac_api_client import Client
 

--- a/use-api.md
+++ b/use-api.md
@@ -4,18 +4,18 @@ title:  "How to Use the API"
 ---
 
 ## Access methods 
-The API is public and available for GET requests at https://api.rockarch.org. 
+The API is public and available for GET requests at [https://api.rockarch.org](https://api.rockarch.org). 
 
-Get started with your favorite API tool or script. We do not require an API key, but please limit your request rate to __ per __. We will throttle requests beyond that to maintain performance and broad access.
+Get started with your favorite API tool or script. We do not require an API key.
 
 If you are new to scripting or working with APIs, consider using a tool like [Hoppscotch](https://hoppscotch.io/) or [Postman](https://www.postman.com/).
 
-- We provide an API client to simplify requests if you are writing Python scripts: [rac_api_client](https://pypi.org/project/rac-api-client/)
+- We provide an [API client](https://pypi.org/project/rac-api-client/) to simplify requests if you are writing Python scripts.
 - Browse the API online at [https://api.rockarch.org](https://api.rockarch.org)
 
 
 ## Quick start 
-Data is accessed through GET requests using API endpoints. For a list of available endpoints, see the [endpoints and parameters](endpoints-and-parameters) section of this document.
+Data is accessed through GET requests using API endpoints. For a list of available endpoints, see the [endpoints and parameters](#endpoints-and-parameters) section of this document.
 
 Examples:
 
@@ -119,7 +119,8 @@ https://api.rockarch.org/collections/2HnhFZfibK6SVVu86skz3k/minimap?query=agricu
 
 Creators are the people, organizations, or families responsible for creating the records.
 Terms are controlled values describing topics, geographic places, or record formats.
-```
+
+```python
 # import rac_api_client module
 from rac_api_client import Client
 

--- a/use-api.md
+++ b/use-api.md
@@ -75,8 +75,6 @@ See the full OpenAPI schema at [https://api.rockarch.org/schema](https://api.roc
 |/objects|Returns a list of objects. Objects are intellectually significant groups of records that do not have children.|
 |/objects/{id}|Returns data about an individual object.|
 |/objects/{id}/ancestors|Returns the ancestors of an object.|
-|/terms|Returns a list of terms. Terms are controlled values describing topics, geographic places or record formats.|
-|/terms/{id}|Returns data about an individual term.|
 |/search|Performs search queries across agents, collections, objects and terms.|
 |/search/{id}|Performs search queries across a specific agent, collection, object or term.
 |/schema/|Returns the OpenAPI schema for the RAC API.|
@@ -114,7 +112,7 @@ https://api.rockarch.org/search?&query=agriculture&category=collection&genre=pho
 https://api.rockarch.org/collections/2HnhFZfibK6SVVu86skz3k/minimap?query=agriculture
 ```
 
-3. Write a Python script using the [rac_api_client](https://pypi.org/project/rac-api-client/) to identify the creators (people or organizations) of collections that contain keyword search matches for "green revolution". The `/search` endpoint performs search queries across agents, collections, objects and terms. 
+3. Write a Python script using the [rac_api_client](https://pypi.org/project/rac-api-client/) to identify the creators (people or organizations) of collections that contain keyword search matches for "green revolution". The `/search` endpoint performs search queries across agents, collections, objects, and terms (terms are controlled values describing topics, geographic places or record formats). 
 
 ```
 # import rac_api_client module

--- a/use-api.md
+++ b/use-api.md
@@ -4,22 +4,115 @@ title:  "How to Use the API"
 ---
 
 ## Access methods 
+The API is public and available for GET requests at https://api.rockarch.org. 
+
+Get started with your favorite API tool or script. We do not require an API key, but please limit your request rate to __ per __. We will throttle requests beyond that to maintain performance and broad access.
+
+If you are new to scripting or working with APIs, consider using a tool like [Hoppscotch](https://hoppscotch.io/) or [Postman](https://www.postman.com/).
+
+- We provide an API client to simplify requests if you are writing Python scripts: [rac_api_client](https://pypi.org/project/rac-api-client/)
+- Browse the API online at [https://api.rockarch.org](https://api.rockarch.org)
+
 
 ## Quick start 
+Data is accessed through GET requests using API endpoints. For a list of available endpoints, see the [endpoints and parameters](endpoints-and-parameters) section of this document.
 
-### Construct a query 
+Examples:
 
-### Understand the data that comes back 
+1. Use the `/collections` endpoint to get a list of all of our archival collections, which are intellectually significant groups of records:
+```
+GET https://api.rockarch.org/collections
+```
+2. Get data about one specific collection, replacing {id} with the collection's identifier (example id: `H45i6yf7MUHuaRwQVupvg5`):
 
-### How to store the data 
+```
+GET https://api.rockarch.org/collections/{id}
+```
+See what a response looks like in the browseable API by opening the link in your browser: [https://api.rockarch.org/collections/H45i6yf7MUHuaRwQVupvg5](https://api.rockarch.org/collections/H45i6yf7MUHuaRwQVupvg5).
 
-## Expected responses, endpoints, and parameters 
+3. Use the `/objects` endpoint and `online` parameter to get data for all archival objects that have digital versions available. Objects are defined as intellectually significant groups of records in a collection that do not have children:
 
-[Link to autodocs-created page] 
+```
+GET https://api.rockarch.org/objects?online=true
+```
 
-## Example scripts 
+Note that `online` is a query parameter. By convention, these are included after a `?` in the URL. To add multiple query parameters, separate the parameters by `&`. For example, to use both the `online` and `start_date` query parameters:
+
+```
+https://api.rockarch.org/objects?online=true&start_date=1950
+```
+
+## Understanding the data that comes back 
+We provide [JSON](https://www.json.org/json-en.html)-formatted data.
+
+Endpoints are paginated. We show 50 records per page by default. Pagination can be controlled via the following query parameters:
+ - `limit` to set how many records each page will return
+ - `offset` to request a specific page of results.
+
+Example: get the **second** page of agent records consisting of **10** records:
+
+```
+GET https://api.rockarch.org/agents?limit=10&offset=10
+```
+
+## Endpoints and parameters
+
+ Using the available endpoints and their parameters, you can construct queries to get data back from the API. 
+
+See the full OpenAPI schema at [https://api.rockarch.org/schema](https://api.rockarch.org/schema) to see how our API is structured and understand the data.
+
+### Endpoints
+
+| Endpoint | Description  |
+|------|------|
+|/agents|Returns a list of agents. Agents are people, organizations or families.|
+|/agents/{id}|Returns data about an individual agent.|
+|/collections|Returns a list of collections. Collections are intellectually significant groups of records.|
+|/collections/{id}|Returns data about an individual collection.|
+|/collections/{id}/ancestors|Returns the ancestors of a collection.|
+|/collections/{id}/children|Returns the children of a collection.|
+|/collections/{id}/minimap|Returns data about where search hits are located within a collection.|
+|/objects|Returns a list of objects. Objects are intellectually significant groups of records that do not have children.|
+|/objects/{id}|Returns data about an individual object.|
+|/objects/{id}/ancestors|Returns the ancestors of an object.|
+|/terms|Returns a list of terms. Terms are controlled values describing topics, geographic places or record formats.|
+|/terms/{id}|Returns data about an individual term.|
+|/search|Performs search queries across agents, collections, objects and terms.|
+|/search/{id}|Performs search queries across a specific agent, collection, object or term.
+|/schema/|Returns the OpenAPI schema for the RAC API.|
+
+### Parameters
+Use our [browseable API](https://api.rockarch.org) to see which parameters are available for which endpoints. For example, [https://api.rockarch.org/collections](https://api.rockarch.org/collections) lists the filter and sort fields, or parameters, that are available for that endpoint at the top of the webpage.
+
+| Parameter | Description | Example |
+|------|------|------|------|
+|id|Identifier that can be used in an endpoint path to point to a specific collection, object, agent, or term.|/collections/2HnhFZfibK6SVVu86skz3k|
+|limit|Number of results to return per page.|limit=50|
+|offset|Number of results to return per page.|offset=50|
+|title|Filter or sort results by title.|title=ford foundation records|
+|start_date|Filter results by start date.|start_date=1932|
+|end_date|Filter results by start date.|end_date=1975|
+|query|Query for full-text search|query=yellow fever|
+|category|Filter results by agent category, including `person`, `collection`, or `organization`|category=person|
+|online|Filter results by objects that are digital and available to view online.|online=true|
+|genre|Filters results by the genre of an archival object, including `documents`, `photographs`, `moving image`, and `audio`.|genre=moving image|
+|sort|Sort results by title, start_date, end_date, or type. By default the named property will be sorted ascending. Descending order can be achieved by appending an en dash (`-`) to the start of the property.|sort=title|
 
 
+## Example queries
+1. Use the `/search` endpoint to return the number of search matches for the query term "agriculture" that are in collections and have been categorized as photographs with dates between 1940 and 1950:
+
+```
+https://api.rockarch.org/search?&query=agriculture&category=collection&genre=photographs&start_date__gte=1940&end_date__lte=1950
+```
+
+**Note**: Appending `__gte` and `__lte` to the date parameters function as `greater than or equal to` and `less than or equal to`, allowing us to include any start and end dates in this decade instead of limiting ourselves to specific start and end dates. Similarly, `gt`= greater than and `ls`= less than.
+
+2. Use the `/minimap` endpoint to return collections and objects with search hits for the query term "agriculture" within the Ford Foundation records collection:
+
+```
+https://api.rockarch.org/collections/2HnhFZfibK6SVVu86skz3k/minimap?query=agriculture
+```
 
 ## Bulk download 
-You can access [exports of our public collections data](https://github.com/RockefellerArchiveCenter/data) on GitHub. The data is exported on a bi-monthly basis.
+You can access [exports of our public collections data](https://github.com/RockefellerArchiveCenter/data) on GitHub. The data is generally exported on a bi-monthly basis.

--- a/use-api.md
+++ b/use-api.md
@@ -106,7 +106,7 @@ Use our [browseable API](https://api.rockarch.org) to see which parameters are a
 
 ### Using URLS
 
-Example 1:
+#### Example 1
 Use the `/search` endpoint to return the number of search matches for the query term "agriculture" that are in collections and have been categorized as photographs with dates between 1940 and 1950:
 
 ```
@@ -115,7 +115,7 @@ https://api.rockarch.org/search?&query=agriculture&category=collection&genre=pho
 
 **Note**: Appending `__gte` and `__lte` to the date parameters function as `greater than or equal to` and `less than or equal to`, allowing us to include any start and end dates in this decade instead of limiting ourselves to specific start and end dates. Similarly, `gt`= greater than and `lt`= less than.
 
-Example 2:
+#### Example 2
 Use the `/minimap` endpoint to return collections and objects with search hits for the query term "agriculture" within the Ford Foundation records collection:
 
 ```
@@ -125,7 +125,7 @@ https://api.rockarch.org/collections/2HnhFZfibK6SVVu86skz3k/minimap?query=agricu
 ### Using the API client with Python
 Example Python scripts that uses the [RAC API client](https://pypi.org/project/rac-api-client/):
 
-Example 1:
+#### Example 1
 Find out the physical size (called extent) of the Social Science Research Council records collection in the archives.
 
 ```python
@@ -137,8 +137,10 @@ response = client.get("/collections/iNo7dbyWw2GwSwKsC3nDj3")
 # print collection title
 print(response["title"])
 
-#print collection extent value and type to get size
-print(response["extents"][0]["value"], response["extents"][0]["type"])
+# print collection extent value and type to get size
+for extent in response["extents"]:
+    print(extent["value"], extent["type"])
+
 ```
 
 Result:
@@ -148,7 +150,7 @@ Social Science Research Council records
 509.06 Cubic Feet
 ```
 
-Example 2:
+#### Example 2
 Identify the creators of collections that contain keyword search matches for "public television". The `/search` endpoint performs search queries across agents, collections, objects, and terms.
 
 Creators are the people, organizations, or families responsible for creating the records. Terms are controlled values describing topics, geographic places, or record formats.

--- a/use-api.md
+++ b/use-api.md
@@ -19,6 +19,7 @@ Data is accessed through GET requests using API endpoints. For a list of availab
 
 Example 1:
 Use the `/collections` endpoint to get a list of all of our archival collections, which are intellectually significant groups of records:
+
 ```
 GET https://api.rockarch.org/collections
 ```
@@ -130,17 +131,17 @@ Find out the physical size (called extent) of the Social Science Research Counci
 
 ```python
 
-# get the collection data about the Social Science Research Council records using the collection id.
+# get the collection data about the Social Science Research Council 
+# records using the collection id.
 client = Client()
-response = client.get("/collections/iNo7dbyWw2GwSwKsC3nDj3")
+collection = client.get("/collections/iNo7dbyWw2GwSwKsC3nDj3")
 
 # print collection title
-print(response["title"])
+print(collection["title"])
 
 # print collection extent value and type to get size
-for extent in response["extents"]:
+for extent in collection["extents"]:
     print(extent["value"], extent["type"])
-
 ```
 
 Result:
@@ -160,17 +161,18 @@ Creators are the people, organizations, or families responsible for creating the
 # import rac_api_client module
 from rac_api_client import Client
 
-# create an empty list of creators (people or organization) of collections that contain search matches for the query
-creator_list = []
+# create an empty set of creators (people or organization) of collections 
+# that contain search matches for the query
+creator_set = set()
 
-# search across agents, collections, objects and terms for "green revolution"
+# search across agents, collections, objects and terms for "public television"
+# add the associated creators to the creator set
 client = Client()
-for response in client.get_paged("/search", params={"query": "public television"}):
-  for creator in (response["creators"]):
-    creator_list.append(creator)
+for records in client.get_paged("/search", params={"query": "public television"}):
+  creator_set.add(*records["creators"])
 
-# get a list of creators with no duplicated names
-dedup_creator_list = list(set(creator_list))
+# convert the set to a list of creators with no duplicated names
+dedup_creator_list = list(creator_set)
 
 # print deduplicated list of creators
 print(dedup_creator_list)

--- a/use-api.md
+++ b/use-api.md
@@ -16,14 +16,14 @@ Get started with your favorite API tool or script. We do not require an API key.
 ## Quick start 
 Data is accessed through GET requests using API endpoints. For a list of available endpoints, see the [endpoints and parameters](/argo/endpoints-parameters) section of this document.
 
-Example 1:
+### Example 1: Get all collections
 Use the `/collections` endpoint to get a list of all of our archival collections, which are intellectually significant groups of records:
 
 ```
 GET https://api.rockarch.org/collections
 ```
 
-Example 2:
+### Example 2: Get a specific collection
 Get data about one specific collection, replacing {id} with the collection's identifier (example id: `H45i6yf7MUHuaRwQVupvg5`). Collection identifiers can be found in the `/collections` or `/search` endpoints as the URI value of a collection. They can also be found in DIMES URLs, since DIMES uses the API. For example: `https://dimes.rockarch.org/collections/H45i6yf7MUHuaRwQVupvg5`: 
 
 ```
@@ -31,7 +31,7 @@ GET https://api.rockarch.org/collections/{id}
 ```
 See what a response looks like in the browsable API by opening the link in your browser: [https://api.rockarch.org/collections/H45i6yf7MUHuaRwQVupvg5](https://api.rockarch.org/collections/H45i6yf7MUHuaRwQVupvg5).
 
-Example 3:
+### Example 3: Get objects that are available to view online
 Use the `/objects` endpoint and `online` parameter to get data for all archival objects that have digital versions available. Objects are defined as intellectually significant groups of records in a collection that do not have children:
 
 ```
@@ -61,7 +61,7 @@ GET https://api.rockarch.org/agents?limit=10&offset=10
 
 ### Using URLS
 
-#### Example 1
+#### Example 1: Search
 Use the `/search` endpoint to return the number of search matches for the query term "agriculture" that are in collections and have been categorized as photographs with dates between 1940 and 1950:
 
 ```
@@ -70,7 +70,7 @@ https://api.rockarch.org/search?&query=agriculture&category=collection&genre=pho
 
 **Note**: Appending `__gte` and `__lte` to the date parameters function as `greater than or equal to` and `less than or equal to`, allowing us to include any start and end dates in this decade instead of limiting ourselves to specific start and end dates. Similarly, `gt`= greater than and `lt`= less than.
 
-#### Example 2
+#### Example 2: Minimap
 Use the `/minimap` endpoint to return collections and objects with search hits for the query term "agriculture" within the Ford Foundation records collection:
 
 ```
@@ -80,7 +80,7 @@ https://api.rockarch.org/collections/2HnhFZfibK6SVVu86skz3k/minimap?query=agricu
 ### Using the API client with Python
 Example Python scripts that uses the [RAC API client](https://pypi.org/project/rac-api-client/):
 
-#### Example 1
+#### Example 1: Size of collection
 Find out the physical size (called extent) of the Social Science Research Council records collection in the archives.
 
 ```python
@@ -107,7 +107,7 @@ Social Science Research Council records
 509.06 Cubic Feet
 ```
 
-#### Example 2
+#### Example 2: Collection creators
 Identify the creators of collections that contain keyword search matches for "public television". The `/search` endpoint performs search queries across agents, collections, objects, and terms.
 
 Creators are the people, organizations, or families responsible for creating the records. Terms are controlled values describing topics, geographic places, or record formats.

--- a/use-api.md
+++ b/use-api.md
@@ -84,18 +84,19 @@ Use our [browseable API](https://api.rockarch.org) to see which parameters are a
 
 | Parameter | Description | Example |
 |------|------|------|------|
-|id|Identifier that can be used in an endpoint path to point to a specific collection, object, agent, or term.|/collections/2HnhFZfibK6SVVu86skz3k|
 |limit|Number of results to return per page.|limit=50|
 |offset|Number of results to return per page.|offset=50|
-|title|Filter or sort results by title.|title=ford foundation records|
+|id|Unique identifier. The id is used in an endpoint path to point to a specific collection, object, agents, etc.|/collections/2HnhFZfibK6SVVu86skz3k|
+|title|Filter or sort results by title.|title=world health organization|
 |start_date|Filter results by start date.|start_date=1932|
 |end_date|Filter results by start date.|end_date=1975|
-|query|Query for full-text search|query=yellow fever|
-|category|Filter results by agent category, including `person`, `collection`, or `organization`|category=person|
+|category|Filter results by category term, including `person`, `collection`, or `organization`|category=person|
+|subject|Filter results by subject/topic term|subject=public health|
+|creator|Filter results by creator. Creators are the people, organizations, and families responsible for creating the records.|creator=adams, lillian|
 |online|Filter results by objects that are digital and available to view online.|online=true|
-|genre|Filters results by the genre of an archival object, including `documents`, `photographs`, `moving image`, and `audio`.|genre=moving image|
+|genre|Filters results by genre/format term, including `documents`, `photographs`, `moving image`, and `audio`.|genre=moving image|
+|query|Query for full-text search|query=yellow fever|
 |sort|Sort results by title, start_date, end_date, or type. By default the named property will be sorted ascending. Descending order can be achieved by appending an en dash (`-`) to the start of the property.|sort=title|
-
 
 ## Example queries
 1. Use the `/search` endpoint to return the number of search matches for the query term "agriculture" that are in collections and have been categorized as photographs with dates between 1940 and 1950:
@@ -112,8 +113,10 @@ https://api.rockarch.org/search?&query=agriculture&category=collection&genre=pho
 https://api.rockarch.org/collections/2HnhFZfibK6SVVu86skz3k/minimap?query=agriculture
 ```
 
-3. Write a Python script using the [rac_api_client](https://pypi.org/project/rac-api-client/) to identify the creators (people or organizations) of collections that contain keyword search matches for "green revolution". The `/search` endpoint performs search queries across agents, collections, objects, and terms (terms are controlled values describing topics, geographic places or record formats). 
+3. Write a Python script using the [rac_api_client](https://pypi.org/project/rac-api-client/) to identify the creators of collections that contain keyword search matches for "green revolution". The `/search` endpoint performs search queries across agents, collections, objects, and terms.
 
+Creators are the people, organizations, or families responsible for creating the records.
+Terms are controlled values describing topics, geographic places, or record formats.
 ```
 # import rac_api_client module
 from rac_api_client import Client
@@ -122,7 +125,7 @@ from rac_api_client import Client
 client = Client()
 response = client.get("/search", params={"query": "green revolution"})
 
-# create a list of creators (people or organization) of collections that contain search matches for the query
+# compile a list of creators of collections that contain search matches for the query
 creator_list = []
 
 for collection in response["results"]:

--- a/use-api.md
+++ b/use-api.md
@@ -1,0 +1,25 @@
+---
+layout: docs
+title:  "How to Use the API"
+---
+
+## Access methods 
+
+## Quick start 
+
+### Construct a query 
+
+### Understand the data that comes back 
+
+### How to store the data 
+
+## Expected responses, endpoints, and parameters 
+
+[Link to autodocs-created page] 
+
+## Example scripts 
+
+
+
+## Bulk download 
+You can access [exports of our public collections data](https://github.com/RockefellerArchiveCenter/data) on GitHub. The data is exported on a bi-monthly basis.

--- a/use-api.md
+++ b/use-api.md
@@ -75,6 +75,8 @@ See the full OpenAPI schema at [https://api.rockarch.org/schema](https://api.roc
 |/objects|Returns a list of objects. Objects are intellectually significant groups of records that do not have children.|
 |/objects/{id}|Returns data about an individual object.|
 |/objects/{id}/ancestors|Returns the ancestors of an object.|
+|/terms|Returns a list of terms. Terms are controlled values describing topics, geographic places or record formats.|
+|/terms/{id}|Returns data about an individual term.|
 |/search|Performs search queries across agents, collections, objects and terms.|
 |/search/{id}|Performs search queries across a specific agent, collection, object or term.
 |/schema/|Returns the OpenAPI schema for the RAC API.|

--- a/use-api.md
+++ b/use-api.md
@@ -8,10 +8,9 @@ The API is public and available for GET requests at [https://api.rockarch.org](h
 
 Get started with your favorite API tool or script. We do not require an API key.
 
-If you are new to scripting or working with APIs, consider using a tool like [Hoppscotch](https://hoppscotch.io/) or [Postman](https://www.postman.com/).
-
+- If you are new to scripting or working with APIs, consider using a tool like [Hoppscotch](https://hoppscotch.io/) or [Postman](https://www.postman.com/).
+- Browse the API online at [https://api.rockarch.org](https://api.rockarch.org).
 - We provide an [API client](https://pypi.org/project/rac-api-client/) to simplify requests if you are writing Python scripts.
-- Browse the API online at [https://api.rockarch.org](https://api.rockarch.org)
 
 
 ## Quick start 


### PR DESCRIPTION
Adds documentation to introduce and provide instructions for researchers/users to access the RAC collections API.

Note: There is a link to an example blog post on the `index.md` page that is not active yet. That will be a post by Hillel on his experiment to visualize the distribution of different terms across collections.