### PR TITLE
Add link to API user docs

### DIFF
--- a/api_formatter/static/css/styles.css
+++ b/api_formatter/static/css/styles.css
@@ -7,3 +7,35 @@ html {
     background-color: #f7f7f9;
     border: 1px solid #e1e1e8;
 }
+
+/* improve color contrast */
+a {
+  color: #0069d9;
+}
+
+.breadcrumb-item.active {
+  color: #616A70;
+}
+
+.page-link {
+  color: #0069d9;
+}
+
+.btn-primary, .page-item.active {
+  background-color: #0069d9;
+  border-color: #0069d9;
+}
+
+.btn-primary:hover, .btn-outline-primary:hover {
+    background-color: #004FA3;
+    border-color: #004FA3;
+}
+
+.btn-outline-primary {
+  border-color: #0069d9;
+  color: #0069d9;
+}
+
+.nav-link:hover, .page-link:hover {
+  text-decoration: underline;
+}

--- a/api_formatter/templates/rest_framework/api.html
+++ b/api_formatter/templates/rest_framework/api.html
@@ -12,20 +12,26 @@
 {% block title %}{% if name %}{{ name }} – {% endif %}RAC API{% endblock %}
 
 {% block navbar %}
-<div class="navbar navbar-static-top navbar-expand navbar-dark bg-dark mb-3"
-     role="navigation" aria-label="{% trans "navbar" %}">
-  <div class="container">
-    {% block branding %}
-    <a class="navbar-brand" rel="nofollow" href="/">RAC API</a>
-    {% endblock %}
-    <ul class="navbar-nav mr-auto">
-      <li class="nav-item"><a class="nav-link" href="{% url 'agent-list' %}">Agents</a></li>
-      <li class="nav-item"><a class="nav-link" href="{% url 'collection-list' %}">Collections</a></li>
-      <li class="nav-item"><a class="nav-link" href="{% url 'object-list' %}">Objects</a></li>
-      <li class="nav-item"><a class="nav-link" href="https://docs.rockarch.org/argo">Help</a></li>
-    </ul>
-  </div>
-</div>
+<header class="main-header">
+  <nav class="navbar navbar-expand-sm navbar-dark bg-dark mb-5" role="navigation" aria-label="{% trans "navbar" %}">
+    <div class="container">
+      <a class="navbar-brand" href="/">RAC API</a>
+
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+
+      <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <ul class="navbar-nav mr-auto">
+          <li class="nav-item"><a class="nav-link text-light" href="{% url 'agent-list' %}">Agents</a></li>
+          <li class="nav-item"><a class="nav-link text-light" href="{% url 'collection-list' %}">Collections</a></li>
+          <li class="nav-item"><a class="nav-link text-light" href="{% url 'object-list' %}">Objects</a></li>
+          <li class="nav-item"><a class="nav-link text-light" href="https://docs.rockarch.org/argo">Documentation</a></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+</header>
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/api_formatter/templates/rest_framework/api.html
+++ b/api_formatter/templates/rest_framework/api.html
@@ -22,6 +22,7 @@
       <li class="nav-item"><a class="nav-link" href="{% url 'agent-list' %}">Agents</a></li>
       <li class="nav-item"><a class="nav-link" href="{% url 'collection-list' %}">Collections</a></li>
       <li class="nav-item"><a class="nav-link" href="{% url 'object-list' %}">Objects</a></li>
+      <li class="nav-item"><a class="nav-link" href="https://docs.rockarch.org/argo">Help</a></li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
- Adds a link to docs.rockarch.org/argo in the header
- Makes nav responsive
- Also improves color contrast for better accessibility (using the same colors as Aquila)

I'd love review/input on what to title the link. I called it "Help" to keep things short and clearly distinguish from the endpoints, but am open to other ideas.

Update: changed "Help" to Documentation"