### PR TITLE
Update UI Header Link to API Docs

### DIFF
--- a/api_formatter/templates/rest_framework/api.html
+++ b/api_formatter/templates/rest_framework/api.html
@@ -26,7 +26,7 @@
           <li class="nav-item"><a class="nav-link text-light" href="{% url 'agent-list' %}">Agents</a></li>
           <li class="nav-item"><a class="nav-link text-light" href="{% url 'collection-list' %}">Collections</a></li>
           <li class="nav-item"><a class="nav-link text-light" href="{% url 'object-list' %}">Objects</a></li>
-          <li class="nav-item"><a class="nav-link text-light" href="https://docs.rockarch.org/argo">Documentation</a></li>
+          <li class="nav-item"><a class="nav-link text-light" href="https://docs.rockarch.org/argo-docs">Documentation</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Update link to API documentation from `https://docs.rockarch.org/argo` to `https://docs.rockarch.org/argo-docs`