### PR TITLE
Change psycopg2 version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ djangorestframework~=3.13
 elasticsearch~=7.17
 elasticsearch-dsl~=7.4
 jsonschema~=4.7
-psycopg2-binary~=2.9
+psycopg2-binary==2.9.3
 PyYAML~=6.0
 rac-schemas~=0.30
 rac_es~=1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,13 +42,13 @@ elasticsearch-dsl==7.4.0
     #   django-elasticsearch-dsl
     #   django-elasticsearch-dsl-drf
     #   rac-es
-jsonschema==4.16.0
+jsonschema==4.17.0
     # via
     #   -r requirements.in
     #   rac-schemas
-psycopg2-binary==2.9.5
+psycopg2-binary==2.9.3
     # via -r requirements.in
-pyrsistent==0.19.1
+pyrsistent==0.19.2
     # via jsonschema
 python-dateutil==2.8.2
     # via elasticsearch-dsl
@@ -60,7 +60,7 @@ rac-es==1.0.0
     # via -r requirements.in
 rac-schemas==0.30
     # via -r requirements.in
-shortuuid==1.0.9
+shortuuid==1.0.11
     # via -r requirements.in
 six==1.16.0
     # via


### PR DESCRIPTION
Downgrades psycopg2 version because of SCRAM authentication issue with ARM architecture.