### PR TITLE
Use psycopg2 instead of psycopg2 binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,9 @@ ENV PYTHONUNBUFFERED 1
 RUN mkdir /code
 WORKDIR /code
 ADD requirements.txt /code/
-RUN pip install --upgrade pip && pip install -r requirements.txt
+RUN \
+  apk add --no-cache postgresql-libs && \
+  apk add --no-cache --virtual .build-deps gcc musl-dev postgresql-dev && \
+  pip install --upgrade pip && pip install -r requirements.txt
+  apk --purge del .build-deps
 ADD . /code/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,5 @@ ENV PYTHONUNBUFFERED 1
 RUN mkdir /code
 WORKDIR /code
 ADD requirements.txt /code/
-RUN \
-  apk add --no-cache postgresql-libs && \
-  apk add --no-cache --virtual .build-deps gcc musl-dev postgresql-dev && \
-  pip install --upgrade pip && pip install -r requirements.txt
-  apk --purge del .build-deps
+RUN pip install --upgrade pip && pip install -r requirements.txt
 ADD . /code/

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ djangorestframework~=3.13
 elasticsearch~=7.17
 elasticsearch-dsl~=7.4
 jsonschema~=4.7
-psycopg2-binary==2.9.3
+psycopg2~=2.9
 PyYAML~=6.0
 rac-schemas~=0.30
 rac_es~=1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,11 +42,11 @@ elasticsearch-dsl==7.4.0
     #   django-elasticsearch-dsl
     #   django-elasticsearch-dsl-drf
     #   rac-es
-jsonschema==4.17.0
+jsonschema==4.17.1
     # via
     #   -r requirements.in
     #   rac-schemas
-psycopg2-binary==2.9.3
+psycopg2==2.9.5
     # via -r requirements.in
 pyrsistent==0.19.2
     # via jsonschema


### PR DESCRIPTION
Uses psycopg2 instead of binary version because of architecture issue.