### PR TITLE
Update RAC stylesheet version with header and footer changes

### DIFF
--- a/api_formatter/templates/rest_framework/api.html
+++ b/api_formatter/templates/rest_framework/api.html
@@ -7,7 +7,7 @@
 {% block style %}
 <!-- <link rel="stylesheet" type="text/css" href="{% static "bootstrap/css/bootstrap.min.css" %}"> -->
 <link rel="icon" type="image/x-icon" href="https://assets.rockarch.org/assets/img/favicon.ico">
-<link rel="stylesheet" type="text/css" href="https://assets.rockarch.org/v0.10.0/main.min.css">
+<link rel="stylesheet" type="text/css" href="https://assets.rockarch.org/v0.12.0/main.min.css">
 <link rel="stylesheet" href="{% static "css/styles.css" %}">
 {% endblock %}
 
@@ -19,9 +19,9 @@
     <div class="container flex">
       <div class="header__brand header__brand--text">
         <a href="/" class="header__brand-title">api.rockarch.org</a>
-        <p class="header__brand-subtitle">
+        <div class="header__brand-subtitle">
           The Collections API of the Rockefeller Archive Center
-        </p>
+        </div>
     </div>
 
     <nav class="nav-right">
@@ -44,7 +44,6 @@
         <li class="nav__item btn--navy">
           <a class="nav__link" href="https://docs.rockarch.org/argo-docs" id="docs">
             Documentation
-            <span class="material-icon" aria-hidden="true">launch</span>
           </a>
         </li>
       </ul>
@@ -84,7 +83,7 @@
 {% block content %}
   <main class="main" id="main">
     <h1>{{ name }}</h1>
-    
+
     {% block breadcrumbs %}
       <nav aria-label="breadcrumbs">
         <ol class="breadcrumbs mt-20">
@@ -229,7 +228,7 @@
           <p class="footer-primary__text">
             Monday-Friday
             <br />
-            9:00 a.m. to 5:00 p.m.
+            9:30 a.m. to 5:00 p.m.
             <br />
             <a
               class="footer-primary__link"
@@ -248,24 +247,6 @@
         </div>
         <div class="footer-primary__social">
           <div class="social-icons">
-            <a href="https://twitter.com/rockarch_org" aria-label="Twitter">
-              <span class="social-icons__icon">
-                <svg
-                  aria-hidden="true"
-                  focusable="false"
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="24"
-                  height="24"
-                  viewBox="0 0 24 24"
-                >
-                  <title>Twitter Logo</title>
-                  <path
-                    fill="#192E49"
-                    d="M24 4.557c-.883.392-1.832.656-2.828.775 1.017-.609 1.798-1.574 2.165-2.724-.951.564-2.005.974-3.127 1.195-.897-.957-2.178-1.555-3.594-1.555-3.179 0-5.515 2.966-4.797 6.045-4.091-.205-7.719-2.165-10.148-5.144-1.29 2.213-.669 5.108 1.523 6.574-.806-.026-1.566-.247-2.229-.616-.054 2.281 1.581 4.415 3.949 4.89-.693.188-1.452.232-2.224.084.626 1.956 2.444 3.379 4.6 3.419-2.07 1.623-4.678 2.348-7.29 2.04 2.179 1.397 4.768 2.212 7.548 2.212 9.142 0 14.307-7.721 13.995-14.646.962-.695 1.797-1.562 2.457-2.549z"
-                  ></path>
-                </svg>
-              </span>
-            </a>
             <a
               href="https://www.facebook.com/RockefellerArchiveCenter"
               aria-label="Facebook"
@@ -308,6 +289,16 @@
                 </svg>
               </span>
             </a>
+            <a href="https://www.linkedin.com/company/rockefeller-archive-center" aria-label="LinkedIn">
+              <span class="social-icons__icon">
+                <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                  <title>LinkedIn Logo</title>
+                  <path transform="scale(1.5)" fill="#192E49"
+                    d="M0 1.146C0 .513.526 0 1.175 0h13.65C15.474 0 16 .513 16 1.146v13.708c0 .633-.526 1.146-1.175 1.146H1.175C.526 16 0 15.487 0 14.854zm4.943 12.248V6.169H2.542v7.225zm-1.2-8.212c.837 0 1.358-.554 1.358-1.248-.015-.709-.52-1.248-1.342-1.248S2.4 3.226 2.4 3.934c0 .694.521 1.248 1.327 1.248zm4.908 8.212V9.359c0-.216.016-.432.08-.586.173-.431.568-.878 1.232-.878.869 0 1.216.662 1.216 1.634v3.865h2.401V9.25c0-2.22-1.184-3.252-2.764-3.252-1.274 0-1.845.7-2.165 1.193v.025h-.016l.016-.025V6.169h-2.4c.03.678 0 7.225 0 7.225z"/>
+                  </path>
+                </svg>
+              </span>
+            </a>
             <a
               href="https://www.youtube.com/channel/UCks9ctz4OF9tMNOTrRkWIZg"
               aria-label="YouTube"
@@ -326,55 +317,6 @@
                     fill="#192E49"
                     d="M19.615 3.184c-3.604-.246-11.631-.245-15.23 0-3.897.266-4.356 2.62-4.385 8.816.029 6.185.484 8.549 4.385 8.816 3.6.245 11.626.246 15.23 0 3.897-.266 4.356-2.62 4.385-8.816-.029-6.185-.484-8.549-4.385-8.816zm-10.615 12.816v-8l8 3.993-8 4.007z"
                   ></path>
-                </svg>
-              </span>
-            </a>
-            <a
-              href="https://www.flickr.com/photos/147074352@N05/"
-              aria-label="Flickr"
-            >
-              <span class="social-icons__icon">
-                <svg
-                  aria-hidden="true"
-                  focusable="false"
-                  width="18px"
-                  height="24px"
-                  viewBox="0 0 18 8"
-                  version="1.1"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <title>Flickr Logo</title>
-                  <g
-                    id="Style-Guide"
-                    stroke="none"
-                    stroke-width="1"
-                    fill="none"
-                    fill-rule="evenodd"
-                  >
-                    <g
-                      id="Style-Guide-/-Navigation"
-                      transform="translate(-1553.000000, -319.000000)"
-                      fill="#192E49"
-                    >
-                      <g
-                        id="Group-2"
-                        transform="translate(1552.999996, 318.500000)"
-                      >
-                        <circle
-                          id="Oval"
-                          cx="3.9374999"
-                          cy="4.41964274"
-                          r="3.9374999"
-                        ></circle>
-                        <circle
-                          id="Oval-Copy-5"
-                          cx="14.0624996"
-                          cy="4.41964274"
-                          r="3.9374999"
-                        ></circle>
-                      </g>
-                    </g>
-                  </g>
                 </svg>
               </span>
             </a>


### PR DESCRIPTION
Fix issue #303 

- Update to RAC styles version 0.12.0
- Update social media links to remove twitter and flickr, and add linkedin
- Update reading room hours in footer
- Remove external link icon in header
- Adjust header semantics to match updates in style library.