### PR TITLE
Fix pagination accessibility and implement RAC style library v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# argo
+# Argo
 
 API middleware which provides a simplified API of data stored in Elasticsearch.
 
-argo is part of [Project Electron](https://github.com/RockefellerArchiveCenter/project_electron), an initiative to build sustainable, open and user-centered infrastructure for the archival management of digital records at the [Rockefeller Archive Center](http://rockarch.org/).
+Argo is part of [Project Electron](https://github.com/RockefellerArchiveCenter/project_electron), an initiative to build sustainable, open and user-centered infrastructure for the archival management of digital records at the [Rockefeller Archive Center](http://rockarch.org/).
 
 ## Setup
 
@@ -13,17 +13,17 @@ Install [git](https://git-scm.com/) and clone the repository
 Install [Docker](https://store.docker.com/search?type=edition&offering=community) and run docker-compose from the root directory
 
     $ cd argo
-    $ docker-compose up
+    $ docker compose up
 
-Once the application starts successfully, you should be able to access the application in your browser at `http://localhost:8000`
+Once the application starts successfully, you should be able to access the application in your browser at `http://localhost:8014`
 
 When you're done, shut down docker-compose
 
-    $ docker-compose down
+    $ docker compose down
 
 Or, if you want to remove all data
 
-    $ docker-compose down -v
+    $ docker compose down -v
 
 
 ## Configuring

--- a/api_formatter/templates/rest_framework/api.html
+++ b/api_formatter/templates/rest_framework/api.html
@@ -7,7 +7,7 @@
 {% block style %}
 <!-- <link rel="stylesheet" type="text/css" href="{% static "bootstrap/css/bootstrap.min.css" %}"> -->
 <link rel="icon" type="image/x-icon" href="https://assets.rockarch.org/assets/img/favicon.ico">
-<link rel="stylesheet" type="text/css" href="https://assets.rockarch.org/v2.0.0/main.min.css">
+<link rel="stylesheet" type="text/css" href="https://assets.rockarch.org/v2.0.3/main.min.css">
 <link rel="stylesheet" href="{% static "css/styles.css" %}">
 {% endblock %}
 

--- a/api_formatter/templates/rest_framework/api.html
+++ b/api_formatter/templates/rest_framework/api.html
@@ -153,7 +153,7 @@
     {% endblock %}
 
     {% if paginator %}
-      <nav>
+      <nav aria-label="pagination">
         {% get_pagination_html paginator %}
       </nav>
     {% endif %}

--- a/api_formatter/templates/rest_framework/api.html
+++ b/api_formatter/templates/rest_framework/api.html
@@ -7,7 +7,7 @@
 {% block style %}
 <!-- <link rel="stylesheet" type="text/css" href="{% static "bootstrap/css/bootstrap.min.css" %}"> -->
 <link rel="icon" type="image/x-icon" href="https://assets.rockarch.org/assets/img/favicon.ico">
-<link rel="stylesheet" type="text/css" href="https://assets.rockarch.org/v1.0.4/main.min.css">
+<link rel="stylesheet" type="text/css" href="https://assets.rockarch.org/v2.0.0/main.min.css">
 <link rel="stylesheet" href="{% static "css/styles.css" %}">
 {% endblock %}
 

--- a/api_formatter/templates/rest_framework/api.html
+++ b/api_formatter/templates/rest_framework/api.html
@@ -7,7 +7,7 @@
 {% block style %}
 <!-- <link rel="stylesheet" type="text/css" href="{% static "bootstrap/css/bootstrap.min.css" %}"> -->
 <link rel="icon" type="image/x-icon" href="https://assets.rockarch.org/assets/img/favicon.ico">
-<link rel="stylesheet" type="text/css" href="https://assets.rockarch.org/v2.0.3/main.min.css">
+<link rel="stylesheet" type="text/css" href="https://assets.rockarch.org/v2.0.4/main.min.css">
 <link rel="stylesheet" href="{% static "css/styles.css" %}">
 {% endblock %}
 

--- a/api_formatter/templates/rest_framework/pagination/numbers.html
+++ b/api_formatter/templates/rest_framework/pagination/numbers.html
@@ -1,14 +1,14 @@
 <ul class="pagination__list">
   {% if previous_url %}
     <li class="pagination__button">
-      <a href="{{ previous_url }}" class="material-icon" aria-disabled="false" aria-label="Previous page" rel="prev">
-        keyboard_arrow_left
+      <a href="{{ previous_url }}" aria-disabled="false" aria-label="Previous page" rel="prev">
+        <span class="material-icon" aria-hidden="true">keyboard_arrow_left</span>
       </a>
     </li>
   {% else %}
     <li class="pagination__button disabled">
-      <a class="material-icon" aria-disabled="true" aria-label="Previous page" rel="prev" >
-        keyboard_arrow_left
+      <a aria-disabled="true" aria-label="Previous page" rel="prev" >
+        <span class="material-icon" aria-hidden="true">keyboard_arrow_left</span>
       </a>
     </li>
   {% endif %}
@@ -16,12 +16,14 @@
   {% for page_link in page_links %}
     {% if page_link.is_break %}
       <li class="pagination__break disabled">
-        <a aria-disabled="true" aria-label="truncated pages">...</a>
+        <a aria-disabled="true" aria-label="truncated pages">
+          <span class="material-icon" aria-hidden="true">...</span>
+        </a>
       </li>
     {% else %}
       {% if page_link.is_active %}
         <li class="pagination__page page__active">
-          <a rel="canonical" aria-label="Page {{page_link.number}} is your current page" aria-current="page" href="{{ page_link.url }}">{{ page_link.number }}</a>
+          <a rel="canonical" aria-current="page" href="{{ page_link.url }}">{{ page_link.number }}</a>
         </li>
       {% else %}
         <li  class="pagination__page">
@@ -33,14 +35,14 @@
 
   {% if next_url %}
     <li class="pagination__button">
-      <a href="{{ next_url }}" class="material-icon" aria-label="Next page" aria-disabled="false" rel="next">
-        keyboard_arrow_right
+      <a href="{{ next_url }}" aria-label="Next page" aria-disabled="false" rel="next">
+        <span class="material-icon" aria-hidden="true">keyboard_arrow_right</span>
       </a>
     </li>
   {% else %}
     <li class="pagination__button disabled">
-      <a class="material-icon" aria-disabled="true" aria-label="Next page" rel="next" >
-        keyboard_arrow_right
+      <a aria-disabled="true" aria-label="Next page" rel="next">
+        <span class="material-icon" aria-hidden="true">keyboard_arrow_right</span>
       </a>
     </li>
   {% endif %}

--- a/api_formatter/templates/rest_framework/pagination/numbers.html
+++ b/api_formatter/templates/rest_framework/pagination/numbers.html
@@ -1,4 +1,4 @@
-<ul class="pagination__list">
+<ol class="pagination__list">
   {% if previous_url %}
     <li class="pagination__button">
       <a href="{{ previous_url }}" aria-disabled="false" aria-label="Previous page" rel="prev">
@@ -15,15 +15,11 @@
 
   {% for page_link in page_links %}
     {% if page_link.is_break %}
-      <li class="pagination__break disabled">
-        <a aria-disabled="true" aria-label="truncated pages">
-          <span class="material-icon" aria-hidden="true">...</span>
-        </a>
-      </li>
+      <li class="pagination__break disabled" aria-label="truncated pages">...</li>
     {% else %}
       {% if page_link.is_active %}
         <li class="pagination__page page__active">
-          <a rel="canonical" aria-current="page" href="{{ page_link.url }}">{{ page_link.number }}</a>
+          <a aria-current="page" href="{{ page_link.url }}">{{ page_link.number }}</a>
         </li>
       {% else %}
         <li  class="pagination__page">
@@ -46,4 +42,4 @@
       </a>
     </li>
   {% endif %}
-</ul>
+</ol>

--- a/api_formatter/templates/rest_framework/pagination/numbers.html
+++ b/api_formatter/templates/rest_framework/pagination/numbers.html
@@ -15,7 +15,10 @@
 
   {% for page_link in page_links %}
     {% if page_link.is_break %}
-      <li class="pagination__break disabled" aria-label="truncated pages">...</li>
+      <li class="pagination__break">
+        <span aria-hidden="true">...</span>
+        <span class="visually-hidden">More pages available</span>
+      </li>
     {% else %}
       {% if page_link.is_active %}
         <li class="pagination__page page__active">


### PR DESCRIPTION
Fixes internal accessibility audit issue 34 related to pagination (along with corresponding updates to the RAC style library component). 

- Uses `ol` instead of `ul`
- Hides icons from screen readers
- Removes link from truncated pages indicator
- Removes `rel="canonical"`, which is not needed here